### PR TITLE
Re-run oldest completed task every tenth assignment

### DIFF
--- a/database.py
+++ b/database.py
@@ -50,6 +50,17 @@ def ensure_schema() -> None:
     )
     """
     )
+    cur.execute(
+        """
+    CREATE TABLE IF NOT EXISTS meta (
+        key TEXT PRIMARY KEY,
+        value INTEGER NOT NULL
+    )
+    """
+    )
+    cur.execute(
+        "INSERT OR IGNORE INTO meta (key, value) VALUES ('task_counter', 0)"
+    )
     conn.commit()
     conn.close()
 


### PR DESCRIPTION
## Summary
- add a meta table to persist application counters and seed a task counter
- update task assignment logic to refresh the oldest completed player every tenth request and clear their old hero stats first

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cd030b84608324a1574e9026b9d18e