### PR TITLE
Switch token persistence to localStorage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -22,7 +22,8 @@
       <section class="card">
         <h2>Stratz Tokens</h2>
         <p>
-          Add one or more Stratz API tokens. They are stored only in your browser as a cookie.
+          Add one or more Stratz API tokens. They are stored only in your browser using local
+          storage.
         </p>
         <div id="tokenList" class="token-list" aria-live="polite"></div>
         <button id="addToken" type="button" class="secondary">Add token</button>


### PR DESCRIPTION
## Summary
- persist saved Stratz API tokens with localStorage instead of cookies and migrate any existing cookie data
- adjust status text to reflect the new storage mechanism

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd374e5e3883249ef5be3f5c69e47c