### PR TITLE
Fix schema initialization for progress endpoints

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,17 +9,16 @@ from heroes import HEROES
 
 app = Flask(__name__, static_folder="static", template_folder="templates")
 
-if not Path(DB_PATH).exists():
-    ensure_schema()
-    conn = db()
-    conn.execute(
-        """
-        INSERT OR IGNORE INTO players (steamAccountId, depth, hero_done, discover_done)
-        VALUES (293053907, 0, 0, 0)
-        """
-    )
-    conn.commit()
-    conn.close()
+ensure_schema()
+conn = db()
+conn.execute(
+    """
+    INSERT OR IGNORE INTO players (steamAccountId, depth, hero_done, discover_done)
+    VALUES (293053907, 0, 0, 0)
+    """
+)
+conn.commit()
+conn.close()
 
 release_incomplete_assignments()
 

--- a/database.py
+++ b/database.py
@@ -12,50 +12,98 @@ def db():
     return conn
 
 
+def _table_columns(cur: sqlite3.Cursor, table: str) -> set[str]:
+    """Return the set of column names that currently exist on *table*."""
+
+    try:
+        rows = cur.execute(f"PRAGMA table_info({table})").fetchall()
+    except sqlite3.DatabaseError:
+        return set()
+    return {row[1] for row in rows}
+
+
 def ensure_schema() -> None:
-    """Recreate the SQLite schema used by the scraper."""
+    """Ensure the SQLite schema exists and upgrade it in place if required."""
 
     Path(DB_PATH).parent.mkdir(parents=True, exist_ok=True)
     conn = db()
     cur = conn.cursor()
-    cur.executescript(
-        """
-        DROP TABLE IF EXISTS hero_stats;
-        DROP TABLE IF EXISTS players;
-        DROP TABLE IF EXISTS meta;
-        DROP TABLE IF EXISTS best;
 
-        CREATE TABLE players (
+    # Players table -----------------------------------------------------------------
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS players (
             steamAccountId INTEGER PRIMARY KEY,
             depth INTEGER,
             assigned_to TEXT,
             assigned_at DATETIME,
             hero_done INTEGER DEFAULT 0,
             discover_done INTEGER DEFAULT 0
-        );
+        )
+        """
+    )
+    player_columns = _table_columns(cur, "players")
+    if "depth" not in player_columns:
+        cur.execute("ALTER TABLE players ADD COLUMN depth INTEGER")
+    if "assigned_to" not in player_columns:
+        cur.execute("ALTER TABLE players ADD COLUMN assigned_to TEXT")
+    if "assigned_at" not in player_columns:
+        cur.execute("ALTER TABLE players ADD COLUMN assigned_at DATETIME")
+    if "hero_done" not in player_columns:
+        cur.execute("ALTER TABLE players ADD COLUMN hero_done INTEGER DEFAULT 0")
+    if "discover_done" not in player_columns:
+        cur.execute(
+            "ALTER TABLE players ADD COLUMN discover_done INTEGER DEFAULT 0"
+        )
 
-        CREATE TABLE hero_stats (
+    # Hero stats table ---------------------------------------------------------------
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS hero_stats (
             steamAccountId INTEGER,
             heroId INTEGER,
             matches INTEGER,
             wins INTEGER,
             PRIMARY KEY (steamAccountId, heroId)
-        );
+        )
+        """
+    )
+    hero_stat_columns = _table_columns(cur, "hero_stats")
+    if "wins" not in hero_stat_columns:
+        cur.execute("ALTER TABLE hero_stats ADD COLUMN wins INTEGER")
 
-        CREATE TABLE best (
+    # Best table --------------------------------------------------------------------
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS best (
             hero_id INTEGER PRIMARY KEY,
             hero_name TEXT,
             player_id INTEGER,
             matches INTEGER,
             wins INTEGER
-        );
-
-        CREATE TABLE meta (
-            key TEXT PRIMARY KEY,
-            value TEXT NOT NULL
-        );
+        )
         """
     )
+    best_columns = _table_columns(cur, "best")
+    if "hero_name" not in best_columns:
+        cur.execute("ALTER TABLE best ADD COLUMN hero_name TEXT")
+    if "player_id" not in best_columns:
+        cur.execute("ALTER TABLE best ADD COLUMN player_id INTEGER")
+    if "matches" not in best_columns:
+        cur.execute("ALTER TABLE best ADD COLUMN matches INTEGER")
+    if "wins" not in best_columns:
+        cur.execute("ALTER TABLE best ADD COLUMN wins INTEGER")
+
+    # Meta table --------------------------------------------------------------------
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        )
+        """
+    )
+
     conn.commit()
     conn.close()
 


### PR DESCRIPTION
## Summary
- ensure the sqlite schema is created or upgraded in place so legacy databases gain the new columns and tables required by the UI
- run the schema check on every startup and seed the root player idempotently to avoid 500 errors when `/progress` or `/best` are queried

## Testing
- python -m compileall app.py database.py heroes.py

------
https://chatgpt.com/codex/tasks/task_e_68cd482537e8832496c9d98d57f68dbc