### PR TITLE
Add hero leaderboards endpoint

### DIFF
--- a/heroes.py
+++ b/heroes.py
@@ -1,5 +1,14 @@
 """Hero metadata for Stratz scraper."""
 
+from typing import Dict, Tuple
+
+
+def hero_slug(name: str) -> str:
+    """Return the canonical slug for a hero name."""
+
+    return name.lower().replace(" ", "_")
+
+
 HEROES_JSON = [
     {"id": 1, "localized_name": "Anti-Mage"},
     {"id": 2, "localized_name": "Axe"},
@@ -130,5 +139,9 @@ HEROES_JSON = [
 ]
 
 HEROES = {hero["id"]: hero["localized_name"] for hero in HEROES_JSON}
+HERO_SLUGS: Dict[str, Tuple[int, str]] = {
+    hero_slug(hero["localized_name"]): (hero["id"], hero["localized_name"])
+    for hero in HEROES_JSON
+}
 
-__all__ = ["HEROES", "HEROES_JSON"]
+__all__ = ["HEROES", "HEROES_JSON", "HERO_SLUGS", "hero_slug"]

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -279,6 +279,16 @@ button:disabled {
   color: var(--muted);
 }
 
+.page-header a {
+  color: var(--accent);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.page-header a:hover {
+  text-decoration: underline;
+}
+
 @media (prefers-color-scheme: dark) {
   .muted {
     color: var(--muted-dark);

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>{{ hero_name }} Leaderboard - Dota Distributed Scraper</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+  </head>
+  <body>
+    <main class="container">
+      <header class="page-header">
+        <div>
+          <h1>{{ hero_name }} Leaderboard</h1>
+          <p class="lead">Top 100 players by matches played on {{ hero_name }}.</p>
+        </div>
+        <a href="{{ url_for('index') }}">Back to dashboard</a>
+      </header>
+
+      <section class="card">
+        <h2>Players</h2>
+        {% if players %}
+        <div class="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Rank</th>
+                <th scope="col">Steam Account ID</th>
+                <th scope="col">Matches</th>
+                <th scope="col">Wins</th>
+                <th scope="col">Win Rate</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for player in players %}
+              {% set win_rate = (player.matches and (player.wins / player.matches * 100)) or 0 %}
+              <tr>
+                <td>{{ loop.index }}</td>
+                <td>{{ player.steamAccountId }}</td>
+                <td>{{ player.matches }}</td>
+                <td>{{ player.wins }}</td>
+                <td>{{ '%.1f' % win_rate }}%</td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        {% else %}
+        <p class="muted">No match data has been collected for {{ hero_name }} yet.</p>
+        {% endif %}
+      </section>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add hero slug mapping utility for hero metadata lookups
- expose a /leaderboards/<hero> endpoint that renders the top 100 players for a hero
- add a leaderboard template and minor styling for the page header link

## Testing
- python -m compileall app.py heroes.py

------
https://chatgpt.com/codex/tasks/task_e_68cd6e7e55788324a155a82c96d52380