### PR TITLE
Prevent duplicate task assignment

### DIFF
--- a/app.py
+++ b/app.py
@@ -72,7 +72,7 @@ def task():
             SELECT steamAccountId
             FROM players
             WHERE hero_done=0
-              AND (assigned_to IS NULL OR assigned_to='hero')
+              AND assigned_to IS NULL
             ORDER BY COALESCE(depth, 0) ASC, steamAccountId ASC
             LIMIT 1
             """
@@ -84,7 +84,7 @@ def task():
                 SET assigned_to='hero',
                     assigned_at=CURRENT_TIMESTAMP
                 WHERE steamAccountId=?
-                  AND (assigned_to IS NULL OR assigned_to='hero')
+                  AND assigned_to IS NULL
                 RETURNING steamAccountId
                 """,
                 (hero_candidate["steamAccountId"],),


### PR DESCRIPTION
## Summary
- continue requiring hero assignments to only occur when no worker is currently assigned
- restore discovery task selection and update filters to their prior (assigned_to is NULL or 'discover') behavior

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cd842c3bc88324bc9ae8f7189458c3