### PR TITLE
Reset hero refresh timestamps once and clear stats on refresh

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from database import (
     ensure_hero_refresh_column,
     ensure_schema,
     release_incomplete_assignments,
+    reset_hero_refresh_once,
 )
 from heroes import HEROES, HERO_SLUGS
 
@@ -29,6 +30,7 @@ if not Path(DB_PATH).exists():
     conn.close()
 
 ensure_hero_refresh_column()
+reset_hero_refresh_once()
 release_incomplete_assignments()
 
 
@@ -271,6 +273,10 @@ def submit():
         conn = db()
         cur = conn.cursor()
         cur.execute("BEGIN")
+        cur.execute(
+            "DELETE FROM hero_stats WHERE steamAccountId = ?",
+            (steam_account_id,),
+        )
         for hero in heroes:
             try:
                 hero_id = int(hero["heroId"])

--- a/database.py
+++ b/database.py
@@ -89,10 +89,35 @@ def ensure_hero_refresh_column() -> None:
     conn.close()
 
 
+def reset_hero_refresh_once() -> None:
+    """Reset hero_refreshed_at for all players the first time the app restarts."""
+
+    conn = db()
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)"
+    )
+    conn.commit()
+    cur.execute("BEGIN")
+    reset_marker = cur.execute(
+        "SELECT value FROM meta WHERE key=?",
+        ("hero_refresh_reset_done",),
+    ).fetchone()
+    if reset_marker is None:
+        cur.execute("UPDATE players SET hero_refreshed_at=NULL")
+        cur.execute(
+            "INSERT INTO meta (key, value) VALUES (?, ?)",
+            ("hero_refresh_reset_done", "1"),
+        )
+    conn.commit()
+    conn.close()
+
+
 __all__ = [
     "db",
     "ensure_schema",
     "release_incomplete_assignments",
     "ensure_hero_refresh_column",
+    "reset_hero_refresh_once",
     "DB_PATH",
 ]


### PR DESCRIPTION
## Summary
- clear out existing hero statistics for a player before storing refreshed data so replacements are accurate
- add a startup routine that resets `hero_refreshed_at` a single time by marking the reset in the `meta` table

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cdeb39028883248034cb6f40e72eb9