### PR TITLE
Prevent hero stat deletion on task reset

### DIFF
--- a/app.py
+++ b/app.py
@@ -214,10 +214,6 @@ def reset_task():
     cur = conn.cursor()
     if task_type == "fetch_hero_stats":
         cur.execute(
-            "DELETE FROM hero_stats WHERE steamAccountId = ?",
-            (steam_account_id,),
-        )
-        cur.execute(
             """
             UPDATE players
             SET hero_done=0,


### PR DESCRIPTION
## Summary
- keep previously stored hero statistics when a fetch task is reset so the data is not wiped prematurely

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68cdecebcff883248003928ddc576267