### PR TITLE
Prevent hero progress loss after hero task reset

### DIFF
--- a/app.py
+++ b/app.py
@@ -213,16 +213,21 @@ def reset_task():
     conn = db()
     cur = conn.cursor()
     if task_type == "fetch_hero_stats":
+        has_existing_stats = cur.execute(
+            "SELECT 1 FROM hero_stats WHERE steamAccountId=? LIMIT 1",
+            (steam_account_id,),
+        ).fetchone()
+        hero_done_value = 1 if has_existing_stats else 0
         cur.execute(
             """
             UPDATE players
-            SET hero_done=0,
-                hero_refreshed_at=NULL,
+            SET hero_done=?,
+                hero_refreshed_at=CASE WHEN ? THEN hero_refreshed_at ELSE NULL END,
                 assigned_to=NULL,
                 assigned_at=NULL
             WHERE steamAccountId=?
             """,
-            (steam_account_id,),
+            (hero_done_value, hero_done_value, steam_account_id),
         )
     elif task_type == "discover_matches":
         cur.execute(


### PR DESCRIPTION
## Summary
- restore hero_done when releasing a failed hero stats task if existing stats are present
- keep hero_refreshed_at timestamps for completed heroes while still clearing assignments

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cdeda3c8d483248bd6c66caa45ecf8