### PR TITLE
Run WAL checkpoint outside of active transaction

### DIFF
--- a/app.py
+++ b/app.py
@@ -184,6 +184,8 @@ def task():
                         "depth": int(depth_value) if depth_value is not None else 0,
                     }
 
+    should_checkpoint = False
+
     if task_payload:
         cur.execute(
             """
@@ -194,10 +196,17 @@ def task():
             ("task_assignment_counter", str(next_count)),
         )
         if checkpoint_due:
-            conn.execute("PRAGMA wal_checkpoint(TRUNCATE);")
+            should_checkpoint = True
 
     conn.commit()
     conn.close()
+
+    if should_checkpoint:
+        checkpoint_conn = db()
+        try:
+            checkpoint_conn.execute("PRAGMA wal_checkpoint(TRUNCATE);")
+        finally:
+            checkpoint_conn.close()
     return jsonify({"task": task_payload})
 
 


### PR DESCRIPTION
## Summary
- avoid running the WAL checkpoint while an IMMEDIATE transaction is active
- perform the checkpoint on a fresh connection after committing updates

## Testing
- python -m compileall app.py database.py heroes.py

------
https://chatgpt.com/codex/tasks/task_e_68ceda562a84832484853f5a5c5f4e3e