### PR TITLE
Remove hero refresh migration helpers

### DIFF
--- a/stratz_scraper/database.py
+++ b/stratz_scraper/database.py
@@ -135,37 +135,12 @@ def release_incomplete_assignments(max_age_minutes: int = 5, existing: sqlite3.C
     return cursor.rowcount if cursor.rowcount is not None else 0
 
 
-def ensure_hero_refresh_column() -> None:
-    with db_connection(write=True) as conn:
-        columns = conn.execute("PRAGMA table_info(players)").fetchall()
-        if not any(column[1] == "hero_refreshed_at" for column in columns):
-            conn.execute("ALTER TABLE players ADD COLUMN hero_refreshed_at DATETIME")
-
-
-def reset_hero_refresh_once() -> None:
-    with db_connection(write=True) as conn:
-        conn.execute("CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
-        conn.execute("BEGIN")
-        reset_marker = conn.execute(
-            "SELECT value FROM meta WHERE key=?",
-            ("hero_refresh_reset_done",),
-        ).fetchone()
-        if reset_marker is None:
-            conn.execute("UPDATE players SET hero_refreshed_at=NULL")
-            conn.execute(
-                "INSERT INTO meta (key, value) VALUES (?, ?)",
-                ("hero_refresh_reset_done", "1"),
-            )
-
-
 __all__ = [
     "connect",
     "db_connection",
     "ensure_schema_exists",
     "ensure_schema",
     "release_incomplete_assignments",
-    "ensure_hero_refresh_column",
-    "reset_hero_refresh_once",
     "DB_PATH",
     "LOCK_PATH",
     "INITIAL_PLAYER_ID",

--- a/stratz_scraper/web/app.py
+++ b/stratz_scraper/web/app.py
@@ -4,12 +4,7 @@ from pathlib import Path
 
 from flask import Flask, Response, abort, jsonify, render_template, request
 
-from ..database import (
-    db_connection,
-    ensure_hero_refresh_column,
-    release_incomplete_assignments,
-    reset_hero_refresh_once,
-)
+from ..database import db_connection, release_incomplete_assignments
 from ..heroes import HEROES, HERO_SLUGS
 
 BASE_DIR = Path(__file__).resolve().parent
@@ -41,8 +36,6 @@ def create_app() -> Flask:
         template_folder=str(TEMPLATE_DIR),
     )
 
-    ensure_hero_refresh_column()
-    reset_hero_refresh_once()
     release_incomplete_assignments()
 
     @app.get("/")


### PR DESCRIPTION
## Summary
- remove the legacy hero refresh maintenance helpers from the database module
- stop invoking the removed helpers at web app startup

## Testing
- python -m compileall stratz_scraper

------
https://chatgpt.com/codex/tasks/task_e_68d1262761dc832486449fe9468c22d6