### PR TITLE
Adjust discovery scheduling cadence

### DIFF
--- a/stratz_scraper/database.py
+++ b/stratz_scraper/database.py
@@ -53,6 +53,7 @@ def ensure_schema(*, lock_acquired: bool = False) -> None:
     with lock_ctx:
         with sqlite3.connect(DB_PATH, timeout=30) as conn:
             conn.execute("PRAGMA busy_timeout = 5000")
+            conn.execute("PRAGMA journal_mode=WAL;")
             conn.executescript(
                 """
                 DROP TABLE IF EXISTS hero_stats;

--- a/stratz_scraper/web/app.py
+++ b/stratz_scraper/web/app.py
@@ -57,6 +57,53 @@ def create_app() -> Flask:
             conn.execute("BEGIN IMMEDIATE")
             release_incomplete_assignments(existing=conn)
             cur = conn.cursor()
+
+            def assign_discovery() -> dict | None:
+                candidate = cur.execute(
+                    """
+                    SELECT steamAccountId, depth
+                    FROM players
+                    WHERE hero_done=1
+                      AND discover_done=0
+                      AND (assigned_to IS NULL OR assigned_to='discover')
+                    ORDER BY COALESCE(depth, 0) ASC, steamAccountId ASC
+                    LIMIT 1
+                    """,
+                ).fetchone()
+                if not candidate:
+                    return None
+                assigned = cur.execute(
+                    """
+                    UPDATE players
+                    SET assigned_to='discover',
+                        assigned_at=CURRENT_TIMESTAMP
+                    WHERE steamAccountId=?
+                      AND (assigned_to IS NULL OR assigned_to='discover')
+                    RETURNING steamAccountId, depth
+                    """,
+                    (candidate["steamAccountId"],),
+                ).fetchone()
+                if not assigned:
+                    return None
+                depth_value = assigned["depth"]
+                return {
+                    "type": "discover_matches",
+                    "steamAccountId": int(assigned["steamAccountId"]),
+                    "depth": int(depth_value) if depth_value is not None else 0,
+                }
+
+            def restart_discovery_cycle() -> bool:
+                cur.execute(
+                    """
+                    UPDATE players
+                    SET discover_done=0,
+                        depth=CASE WHEN depth=0 THEN 0 ELSE NULL END,
+                        assigned_at=CASE WHEN assigned_to='discover' THEN NULL ELSE assigned_at END,
+                        assigned_to=CASE WHEN assigned_to='discover' THEN NULL ELSE assigned_to END
+                    """,
+                )
+                return True
+
             counter_row = cur.execute(
                 "SELECT value FROM meta WHERE key=?",
                 ("task_assignment_counter",),
@@ -67,8 +114,19 @@ def create_app() -> Flask:
                 current_count = 0
             next_count = current_count + 1
             refresh_due = next_count % 10 == 0
+            discovery_due = next_count % 100 == 0
             checkpoint_due = next_count % 10000 == 0
-            if refresh_due:
+
+            should_truncate_wal = False
+
+            if discovery_due:
+                task_payload = assign_discovery()
+                if task_payload is None:
+                    if restart_discovery_cycle():
+                        should_truncate_wal = True
+                        task_payload = assign_discovery()
+
+            if task_payload is None and refresh_due:
                 refresh_candidate = cur.execute(
                     """
                     SELECT steamAccountId
@@ -99,6 +157,7 @@ def create_app() -> Flask:
                             "type": "fetch_hero_stats",
                             "steamAccountId": int(assigned_row["steamAccountId"]),
                         }
+
             if task_payload is None:
                 hero_candidate = cur.execute(
                     """
@@ -128,41 +187,14 @@ def create_app() -> Flask:
                             "type": "fetch_hero_stats",
                             "steamAccountId": int(assigned_row["steamAccountId"]),
                         }
+
             if task_payload is None:
                 hero_pending = cur.execute(
                     "SELECT 1 FROM players WHERE hero_done=0 LIMIT 1"
                 ).fetchone()
-                if not hero_pending:
-                    discover_candidate = cur.execute(
-                        """
-                        SELECT steamAccountId, depth
-                        FROM players
-                        WHERE hero_done=1
-                          AND discover_done=0
-                          AND (assigned_to IS NULL OR assigned_to='discover')
-                        ORDER BY COALESCE(depth, 0) ASC, steamAccountId ASC
-                        LIMIT 1
-                        """,
-                    ).fetchone()
-                    if discover_candidate:
-                        assigned_row = cur.execute(
-                            """
-                            UPDATE players
-                            SET assigned_to='discover',
-                                assigned_at=CURRENT_TIMESTAMP
-                            WHERE steamAccountId=?
-                              AND (assigned_to IS NULL OR assigned_to='discover')
-                            RETURNING steamAccountId, depth
-                            """,
-                            (discover_candidate["steamAccountId"],),
-                        ).fetchone()
-                        if assigned_row:
-                            depth_value = assigned_row["depth"]
-                            task_payload = {
-                                "type": "discover_matches",
-                                "steamAccountId": int(assigned_row["steamAccountId"]),
-                                "depth": int(depth_value) if depth_value is not None else 0,
-                            }
+                if not hero_pending and not discovery_due:
+                    task_payload = assign_discovery()
+
             if task_payload:
                 cur.execute(
                     """
@@ -172,7 +204,7 @@ def create_app() -> Flask:
                     """,
                     ("task_assignment_counter", str(next_count)),
                 )
-                if checkpoint_due:
+                if checkpoint_due or should_truncate_wal:
                     should_checkpoint = True
         if should_checkpoint:
             with db_connection(write=True) as checkpoint_conn:
@@ -322,13 +354,15 @@ def create_app() -> Flask:
                         continue
                     cur.execute(
                         """
-                        INSERT OR IGNORE INTO players (
+                        INSERT INTO players (
                             steamAccountId,
                             depth,
                             hero_done,
                             discover_done
                         )
                         VALUES (?,?,0,0)
+                        ON CONFLICT(steamAccountId) DO UPDATE SET
+                            depth=excluded.depth
                         """,
                         (new_id, next_depth),
                     )


### PR DESCRIPTION
## Summary
- ensure the schema initialization enables SQLite WAL mode
- schedule every 100th task as a discovery job and restart discovery from the beginning when exhausted
- allow rediscovery submissions to update stored depths while truncating the WAL after each reset

## Testing
- python -m compileall stratz_scraper

------
https://chatgpt.com/codex/tasks/task_e_68d1259c378c8324aa06aba2dfce9d7d