### PR TITLE
Optimize discovery submit depth handling

### DIFF
--- a/stratz_scraper/web/app.py
+++ b/stratz_scraper/web/app.py
@@ -374,29 +374,54 @@ def create_app() -> Flask:
                 steam_account_id = int(data["steamAccountId"])
             except (KeyError, TypeError, ValueError):
                 return jsonify({"status": "error", "message": "steamAccountId is required"}), 400
-            discovered_ids = set()
+            discovered_ids: list[int] = []
+            seen_ids: set[int] = set()
             for value in data.get("discovered", []):
                 try:
-                    discovered_ids.add(int(value))
+                    candidate_id = int(value)
                 except (TypeError, ValueError):
                     continue
+                if candidate_id in seen_ids:
+                    continue
+                seen_ids.add(candidate_id)
+                discovered_ids.append(candidate_id)
             with db_connection(write=True) as conn:
                 cur = conn.cursor()
                 cur.execute("BEGIN")
-                parent_row = cur.execute(
-                    "SELECT depth FROM players WHERE steamAccountId=?",
-                    (steam_account_id,),
-                ).fetchone()
-                parent_depth = (
-                    int(parent_row["depth"])
-                    if parent_row and parent_row["depth"] is not None
-                    else 0
-                )
-                next_depth = parent_depth + 1
-                for new_id in discovered_ids:
-                    if new_id == steam_account_id:
-                        continue
-                    cur.execute(
+                next_depth_value = None
+                provided_next_depth = data.get("nextDepth")
+                if provided_next_depth is not None:
+                    try:
+                        next_depth_value = int(provided_next_depth)
+                    except (TypeError, ValueError):
+                        next_depth_value = None
+                if next_depth_value is None:
+                    provided_depth = data.get("depth")
+                    parent_depth_value = None
+                    if provided_depth is not None:
+                        try:
+                            parent_depth_value = int(provided_depth)
+                        except (TypeError, ValueError):
+                            parent_depth_value = None
+                    if parent_depth_value is None:
+                        parent_row = cur.execute(
+                            "SELECT depth FROM players WHERE steamAccountId=?",
+                            (steam_account_id,),
+                        ).fetchone()
+                        parent_depth_value = (
+                            int(parent_row["depth"])
+                            if parent_row and parent_row["depth"] is not None
+                            else 0
+                        )
+                    next_depth_value = parent_depth_value + 1
+
+                child_rows = [
+                    (new_id, next_depth_value)
+                    for new_id in discovered_ids
+                    if new_id != steam_account_id
+                ]
+                if child_rows:
+                    cur.executemany(
                         """
                         INSERT INTO players (
                             steamAccountId,
@@ -408,7 +433,7 @@ def create_app() -> Flask:
                         ON CONFLICT(steamAccountId) DO UPDATE SET
                             depth=excluded.depth
                         """,
-                        (new_id, next_depth),
+                        child_rows,
                     )
                 cur.execute(
                     """

--- a/stratz_scraper/web/static/js/app.js
+++ b/stratz_scraper/web/static/js/app.js
@@ -812,15 +812,19 @@ async function submitHeroStats(playerId, heroes) {
   }
 }
 
-async function submitDiscovery(playerId, discovered) {
+async function submitDiscovery(playerId, discovered, depth) {
+  const payload = {
+    type: "discover_matches",
+    steamAccountId: playerId,
+    discovered,
+  };
+  if (Number.isFinite(depth)) {
+    payload.depth = depth;
+  }
   const response = await fetch("/submit", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      type: "discover_matches",
-      steamAccountId: playerId,
-      discovered,
-    }),
+    body: JSON.stringify(payload),
   });
   if (!response.ok) {
     throw new Error(`Submit failed with status ${response.status}`);
@@ -948,7 +952,7 @@ async function workLoopForToken(token) {
           token,
           `Discovered ${discovered.length} accounts from ${taskId}.`,
         );
-        await submitDiscovery(taskId, discovered);
+        await submitDiscovery(taskId, discovered, task.depth);
         logToken(token, `Submitted discovery results for ${taskId}.`);
       } else {
         logToken(


### PR DESCRIPTION
## Summary
- skip the parent depth lookup when a discovery submission includes depth information and bulk insert the discovered accounts in one statement
- update the browser client to forward the discovery depth from the assigned task so the backend can reuse it

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d196938dfc8324a9d5df0fae9f7df0