### PR TITLE
Ensure database commits use file locks

### DIFF
--- a/stratz_scraper/web/app.py
+++ b/stratz_scraper/web/app.py
@@ -7,6 +7,7 @@ from flask import Flask, Response, abort, jsonify, render_template, request
 
 from ..database import (
     db_connection,
+    locked_commit,
     locked_execute,
     locked_executemany,
     release_incomplete_assignments,
@@ -88,7 +89,7 @@ def create_app() -> Flask:
         with db_connection(write=True) as conn:
             cleanup_ran = maybe_run_assignment_cleanup(conn)
             if cleanup_ran:
-                conn.commit()
+                locked_commit(conn)
             cur = conn.cursor()
 
             def assign_discovery() -> dict | None:


### PR DESCRIPTION
## Summary
- guard sqlite commit and rollback operations with the shared file lock
- expose helpers for locked commit/rollback and use them during assignment cleanup

## Testing
- python -m compileall stratz_scraper

------
https://chatgpt.com/codex/tasks/task_e_68d1da19c2dc8324a08cbc23d27bc8f2