### PR TITLE
Ensure discovery submit uses locking helpers

### DIFF
--- a/stratz_scraper/web/app.py
+++ b/stratz_scraper/web/app.py
@@ -413,7 +413,6 @@ def create_app() -> Flask:
                 discovered_ids.append(candidate_id)
             with db_connection(write=True) as conn:
                 cur = conn.cursor()
-                cur.execute("BEGIN")
                 next_depth_value = None
                 provided_next_depth = data.get("nextDepth")
                 if provided_next_depth is not None:
@@ -430,7 +429,8 @@ def create_app() -> Flask:
                         except (TypeError, ValueError):
                             parent_depth_value = None
                     if parent_depth_value is None:
-                        parent_row = cur.execute(
+                        parent_row = locked_execute(
+                            cur,
                             "SELECT depth FROM players WHERE steamAccountId=?",
                             (steam_account_id,),
                         ).fetchone()


### PR DESCRIPTION
## Summary
- remove the manual BEGIN from the discover_matches submit handler so transactions rely on the managed connection helpers
- ensure the depth lookup for discovery submissions acquires the file lock before touching SQLite

## Testing
- python -m compileall stratz_scraper

------
https://chatgpt.com/codex/tasks/task_e_68d1ddb15f3c8324b56a697bc40bd74e