### PR TITLE
Enable autocommit for database operations

### DIFF
--- a/stratz_scraper/web/app.py
+++ b/stratz_scraper/web/app.py
@@ -7,7 +7,6 @@ from flask import Flask, Response, abort, jsonify, render_template, request
 
 from ..database import (
     db_connection,
-    locked_commit,
     locked_execute,
     locked_executemany,
     release_incomplete_assignments,
@@ -87,9 +86,7 @@ def create_app() -> Flask:
         task_payload = None
         should_checkpoint = False
         with db_connection(write=True) as conn:
-            cleanup_ran = maybe_run_assignment_cleanup(conn)
-            if cleanup_ran:
-                locked_commit(conn)
+            maybe_run_assignment_cleanup(conn)
             cur = conn.cursor()
 
             def assign_discovery() -> dict | None:


### PR DESCRIPTION
## Summary
- configure SQLite connections to use autocommit and simplify the connection helper
- remove the explicit commit and rollback helpers and their usage in the web app

## Testing
- python -m compileall stratz_scraper

------
https://chatgpt.com/codex/tasks/task_e_68d1e1947d04832481f51f7bfea3fd36