### PR TITLE
Throttle progress refresh requests

### DIFF
--- a/stratz_scraper/web/static/js/app.js
+++ b/stratz_scraper/web/static/js/app.js
@@ -1239,7 +1239,7 @@ elements.stop.addEventListener("click", () => {
 });
 
 elements.progress.addEventListener("click", () => {
-  refreshProgress().catch((error) => log(error.message));
+  refreshProgress({ force: true }).catch((error) => log(error.message));
 });
 
 elements.best.addEventListener("click", () => {


### PR DESCRIPTION
## Summary
- cache the most recent `/progress` payload in the browser so updates reuse it instead of re-requesting
- throttle client progress polling to at most one network request every ten seconds and share in-flight fetches

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3a89c9e00832481f9617347d40ffe