### PR TITLE
Add refresh indicator and hero leaderboard links to best table

### DIFF
--- a/stratz_scraper/web/app.py
+++ b/stratz_scraper/web/app.py
@@ -11,7 +11,7 @@ from ..database import (
     locked_executemany,
     release_incomplete_assignments,
 )
-from ..heroes import HEROES, HERO_SLUGS
+from ..heroes import HEROES, HERO_SLUGS, hero_slug
 
 BASE_DIR = Path(__file__).resolve().parent
 STATIC_DIR = BASE_DIR / "static"
@@ -659,6 +659,12 @@ def create_app() -> Flask:
     def best():
         with db_connection() as conn:
             rows = conn.execute("SELECT * FROM best ORDER BY matches DESC").fetchall()
-        return jsonify([dict(row) for row in rows])
+        payload = []
+        for row in rows:
+            row_dict = dict(row)
+            name = row_dict.get("hero_name")
+            row_dict["hero_slug"] = hero_slug(name) if isinstance(name, str) else None
+            payload.append(row_dict)
+        return jsonify(payload)
 
     return app

--- a/stratz_scraper/web/static/css/styles.css
+++ b/stratz_scraper/web/static/css/styles.css
@@ -342,7 +342,42 @@ button:disabled {
 }
 
 .table-wrapper {
+  position: relative;
   overflow-x: auto;
+  min-height: 120px;
+}
+
+.table-wrapper.refreshing::after {
+  content: "Refreshing…";
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 23, 42, 0.55);
+  color: #fff;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: 0.95rem;
+  pointer-events: none;
+}
+
+@media (prefers-color-scheme: light) {
+  .table-wrapper.refreshing::after {
+    background: rgba(15, 23, 42, 0.35);
+  }
+}
+
+.table-wrapper a {
+  color: var(--accent);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.table-wrapper a:hover,
+.table-wrapper a:focus {
+  text-decoration: underline;
 }
 
 .table-wrapper table {


### PR DESCRIPTION
## Summary
- expose hero slugs from the /best API so the client can link to leaderboards
- add hero leaderboard links and HTML escaping when rendering the Top Heroes table
- show a visual refresh indicator while the table data is reloading

## Testing
- python -m compileall stratz_scraper/web/app.py

------
https://chatgpt.com/codex/tasks/task_e_68d3ac781f4c83249048d0bb9d1e2566