### PR TITLE
Add token task time metrics

### DIFF
--- a/stratz_scraper/web/templates/index.html
+++ b/stratz_scraper/web/templates/index.html
@@ -56,6 +56,14 @@
             <span class="label">Requests remaining</span>
             <span id="requestsRemaining" class="value">—</span>
           </div>
+          <div>
+            <span class="label">Avg task time</span>
+            <span id="avgTaskTimeGlobal" class="value">—</span>
+          </div>
+          <div>
+            <span class="label">Expected in 24h</span>
+            <span id="tasksPerDayGlobal" class="value">—</span>
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- track run time and completed task counts for each token session
- render per-token average task time and 24h completion projection along with global metrics

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3cfe9aaf88324855d495c60a99a7a