### PR TITLE
Add User-Agent header to Stratz API requests

### DIFF
--- a/stratz_scraper/web/static/js/app.js
+++ b/stratz_scraper/web/static/js/app.js
@@ -307,6 +307,7 @@ async function executeStratzQueryWithTokens(query, variables, tokens, startIndex
         headers: {
           Authorization: `Bearer ${candidateToken}`,
           "Content-Type": "application/json",
+          "User-Agent": "STRATZ_API",
         },
         body: JSON.stringify({ query, variables }),
       });
@@ -880,6 +881,7 @@ async function fetchPlayerHeroes(playerId, token) {
     headers: {
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
+      'User-Agent': 'STRATZ_API',
     },
     body: JSON.stringify({ query, variables: { id: playerId } }),
   });


### PR DESCRIPTION
## Summary
- add the required STRATZ_API User-Agent header to browser GraphQL requests

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3dc85c6ac8324afd8c8e35375c401