### PR TITLE
Process submit tasks asynchronously

### DIFF
--- a/stratz_scraper/web/app.py
+++ b/stratz_scraper/web/app.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+import traceback
 
 from flask import Flask, Response, abort, jsonify, render_template, request
 
@@ -19,6 +21,8 @@ TEMPLATE_DIR = BASE_DIR / "templates"
 
 ASSIGNMENT_CLEANUP_KEY = "last_assignment_cleanup"
 ASSIGNMENT_CLEANUP_INTERVAL = timedelta(seconds=60)
+
+BACKGROUND_EXECUTOR = ThreadPoolExecutor(max_workers=2)
 
 
 def _parse_sqlite_timestamp(value: str | None) -> datetime | None:
@@ -71,6 +75,163 @@ def record_task_duration(
             flush=True,
         )
     return duration_seconds
+
+
+def _unmark_hero_task(steam_account_id: int) -> None:
+    try:
+        with db_connection(write=True) as conn:
+            cur = conn.cursor()
+            retryable_execute(
+                cur,
+                """
+                UPDATE players
+                SET hero_done=0,
+                    hero_refreshed_at=NULL,
+                    assigned_to=NULL,
+                    assigned_at=NULL
+                WHERE steamAccountId=?
+                """,
+                (steam_account_id,),
+            )
+    except Exception:
+        traceback.print_exc()
+
+
+def _unmark_discover_task(steam_account_id: int) -> None:
+    try:
+        with db_connection(write=True) as conn:
+            cur = conn.cursor()
+            retryable_execute(
+                cur,
+                """
+                UPDATE players
+                SET discover_done=0,
+                    assigned_to=NULL,
+                    assigned_at=NULL
+                WHERE steamAccountId=?
+                """,
+                (steam_account_id,),
+            )
+    except Exception:
+        traceback.print_exc()
+
+
+def _process_hero_submission(
+    steam_account_id: int,
+    hero_stats_rows: list[tuple[int, int, int, int]],
+    best_rows: list[tuple[int, str, int, int, int]],
+    assigned_at_value: str | None,
+) -> None:
+    try:
+        with db_connection(write=True) as conn:
+            cur = conn.cursor()
+            retryable_execute(
+                cur,
+                "DELETE FROM hero_stats WHERE steamAccountId = ?",
+                (steam_account_id,),
+            )
+            if hero_stats_rows:
+                retryable_executemany(
+                    cur,
+                    """
+                    INSERT INTO hero_stats (steamAccountId, heroId, matches, wins)
+                    VALUES (?,?,?,?)
+                    """,
+                    hero_stats_rows,
+                )
+            if best_rows:
+                retryable_executemany(
+                    cur,
+                    """
+                    INSERT INTO best (hero_id, hero_name, player_id, matches, wins)
+                    VALUES (?,?,?,?,?)
+                    ON CONFLICT(hero_id) DO UPDATE SET
+                        matches=excluded.matches,
+                        wins=excluded.wins,
+                        player_id=excluded.player_id
+                    WHERE excluded.matches > best.matches
+                    """,
+                    best_rows,
+                )
+            retryable_execute(
+                cur,
+                """
+                UPDATE players
+                SET hero_done=1,
+                    hero_refreshed_at=CURRENT_TIMESTAMP
+                WHERE steamAccountId=?
+                """,
+                (steam_account_id,),
+            )
+            record_task_duration(
+                cur,
+                steam_account_id,
+                "fetch_hero_stats",
+                assigned_at_value,
+            )
+    except Exception:
+        print(
+            f"[submit-background] failed to process hero stats for {steam_account_id}",
+            flush=True,
+        )
+        traceback.print_exc()
+        _unmark_hero_task(steam_account_id)
+
+
+def _process_discover_submission(
+    steam_account_id: int,
+    discovered_ids: list[int],
+    next_depth_value: int,
+    assigned_at_value: str | None,
+) -> None:
+    try:
+        with db_connection(write=True) as conn:
+            cur = conn.cursor()
+            child_rows = [
+                (new_id, next_depth_value)
+                for new_id in discovered_ids
+                if new_id != steam_account_id
+            ]
+            if child_rows:
+                retryable_executemany(
+                    cur,
+                    """
+                    INSERT INTO players (
+                        steamAccountId,
+                        depth,
+                        hero_done,
+                        discover_done
+                    )
+                    VALUES (?,?,0,0)
+                    ON CONFLICT(steamAccountId) DO UPDATE SET
+                        depth=excluded.depth
+                    """,
+                    child_rows,
+                )
+            retryable_execute(
+                cur,
+                """
+                UPDATE players
+                SET discover_done=1,
+                    assigned_to=NULL,
+                    assigned_at=NULL
+                WHERE steamAccountId=?
+                """,
+                (steam_account_id,),
+            )
+            record_task_duration(
+                cur,
+                steam_account_id,
+                "discover_matches",
+                assigned_at_value,
+            )
+    except Exception:
+        print(
+            f"[submit-background] failed to process discovery for {steam_account_id}",
+            flush=True,
+        )
+        traceback.print_exc()
+        _unmark_discover_task(steam_account_id)
 
 
 def maybe_run_assignment_cleanup(conn) -> bool:
@@ -410,7 +571,8 @@ def create_app() -> Flask:
                     best_rows.append(
                         (hero_id, hero_name, steam_account_id, matches, wins)
                     )
-
+            assigned_at_value = None
+            update_count = 0
             with db_connection(write=True) as conn:
                 cur = conn.cursor()
                 assignment_row = retryable_execute(
@@ -418,55 +580,37 @@ def create_app() -> Flask:
                     "SELECT assigned_at FROM players WHERE steamAccountId=?",
                     (steam_account_id,),
                 ).fetchone()
-                assigned_at_value = (
-                    assignment_row["assigned_at"] if assignment_row is not None else None
-                )
-                retryable_execute(
-                    cur,
-                    "DELETE FROM hero_stats WHERE steamAccountId = ?",
-                    (steam_account_id,),
-                )
-                if hero_stats_rows:
-                    retryable_executemany(
-                        cur,
-                        """
-                        INSERT INTO hero_stats (steamAccountId, heroId, matches, wins)
-                        VALUES (?,?,?,?)
-                        """,
-                        hero_stats_rows,
-                    )
-                if best_rows:
-                    retryable_executemany(
-                        cur,
-                        """
-                        INSERT INTO best (hero_id, hero_name, player_id, matches, wins)
-                        VALUES (?,?,?,?,?)
-                        ON CONFLICT(hero_id) DO UPDATE SET
-                            matches=excluded.matches,
-                            wins=excluded.wins,
-                            player_id=excluded.player_id
-                        WHERE excluded.matches > best.matches
-                        """,
-                        best_rows,
-                    )
-                retryable_execute(
+                if assignment_row is not None:
+                    assigned_at_value = assignment_row["assigned_at"]
+                update_cursor = retryable_execute(
                     cur,
                     """
                     UPDATE players
                     SET hero_done=1,
-                        hero_refreshed_at=CURRENT_TIMESTAMP,
                         assigned_to=NULL,
                         assigned_at=NULL
                     WHERE steamAccountId=?
                     """,
                     (steam_account_id,),
                 )
-                record_task_duration(
-                    cur,
-                    steam_account_id,
-                    "fetch_hero_stats",
-                    assigned_at_value,
+                update_count = update_cursor.rowcount
+            if update_count == 0:
+                return (
+                    jsonify(
+                        {
+                            "status": "error",
+                            "message": "Player not found",
+                        }
+                    ),
+                    404,
                 )
+            BACKGROUND_EXECUTOR.submit(
+                _process_hero_submission,
+                steam_account_id,
+                hero_stats_rows,
+                best_rows,
+                assigned_at_value,
+            )
             next_task = assign_next_task() if request_new_task else None
             response_payload = {"status": "ok"}
             if request_new_task:
@@ -488,9 +632,18 @@ def create_app() -> Flask:
                     continue
                 seen_ids.add(candidate_id)
                 discovered_ids.append(candidate_id)
+            assigned_at_value = None
+            next_depth_value = None
+            update_count = 0
             with db_connection(write=True) as conn:
                 cur = conn.cursor()
-                next_depth_value = None
+                assignment_row = retryable_execute(
+                    cur,
+                    "SELECT assigned_at, depth FROM players WHERE steamAccountId=?",
+                    (steam_account_id,),
+                ).fetchone()
+                if assignment_row is not None:
+                    assigned_at_value = assignment_row["assigned_at"]
                 provided_next_depth = data.get("nextDepth")
                 if provided_next_depth is not None:
                     try:
@@ -506,48 +659,15 @@ def create_app() -> Flask:
                         except (TypeError, ValueError):
                             parent_depth_value = None
                     if parent_depth_value is None:
-                        parent_row = retryable_execute(
-                            cur,
-                            "SELECT depth FROM players WHERE steamAccountId=?",
-                            (steam_account_id,),
-                        ).fetchone()
-                        parent_depth_value = (
-                            int(parent_row["depth"])
-                            if parent_row and parent_row["depth"] is not None
-                            else 0
-                        )
+                        if assignment_row and assignment_row["depth"] is not None:
+                            try:
+                                parent_depth_value = int(assignment_row["depth"])
+                            except (TypeError, ValueError):
+                                parent_depth_value = 0
+                        else:
+                            parent_depth_value = 0
                     next_depth_value = parent_depth_value + 1
-
-                child_rows = [
-                    (new_id, next_depth_value)
-                    for new_id in discovered_ids
-                    if new_id != steam_account_id
-                ]
-                if child_rows:
-                    retryable_executemany(
-                        cur,
-                        """
-                        INSERT INTO players (
-                            steamAccountId,
-                            depth,
-                            hero_done,
-                            discover_done
-                        )
-                        VALUES (?,?,0,0)
-                        ON CONFLICT(steamAccountId) DO UPDATE SET
-                            depth=excluded.depth
-                        """,
-                        child_rows,
-                    )
-                assignment_row = retryable_execute(
-                    cur,
-                    "SELECT assigned_at FROM players WHERE steamAccountId=?",
-                    (steam_account_id,),
-                ).fetchone()
-                assigned_at_value = (
-                    assignment_row["assigned_at"] if assignment_row is not None else None
-                )
-                retryable_execute(
+                update_cursor = retryable_execute(
                     cur,
                     """
                     UPDATE players
@@ -558,12 +678,26 @@ def create_app() -> Flask:
                     """,
                     (steam_account_id,),
                 )
-                record_task_duration(
-                    cur,
-                    steam_account_id,
-                    "discover_matches",
-                    assigned_at_value,
+                update_count = update_cursor.rowcount
+            if update_count == 0:
+                return (
+                    jsonify(
+                        {
+                            "status": "error",
+                            "message": "Player not found",
+                        }
+                    ),
+                    404,
                 )
+            if next_depth_value is None:
+                next_depth_value = 1
+            BACKGROUND_EXECUTOR.submit(
+                _process_discover_submission,
+                steam_account_id,
+                discovered_ids,
+                next_depth_value,
+                assigned_at_value,
+            )
             next_task = assign_next_task() if request_new_task else None
             response_payload = {"status": "ok"}
             if request_new_task:


### PR DESCRIPTION
## Summary
- mark submit requests complete immediately after validating input
- move hero stats and discovery processing into background workers with rollback on failure
- continue returning next tasks without blocking on heavy database writes

## Testing
- python -m compileall stratz_scraper

------
https://chatgpt.com/codex/tasks/task_e_68d3f00f45b4832484ead63cafcdb20d