### PR TITLE
Modularize web application components

### DIFF
--- a/stratz_scraper/web/assignment.py
+++ b/stratz_scraper/web/assignment.py
@@ -1,0 +1,262 @@
+"""Task assignment helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Tuple
+
+from ..database import (
+    db_connection,
+    release_incomplete_assignments,
+    retryable_execute,
+)
+
+ASSIGNMENT_CLEANUP_KEY = "last_assignment_cleanup"
+ASSIGNMENT_CLEANUP_INTERVAL = timedelta(seconds=60)
+
+__all__ = [
+    "ASSIGNMENT_CLEANUP_INTERVAL",
+    "ASSIGNMENT_CLEANUP_KEY",
+    "assign_next_task",
+    "maybe_run_assignment_cleanup",
+]
+
+
+def maybe_run_assignment_cleanup(conn) -> bool:
+    """Release stale assignments if the cleanup interval has elapsed."""
+    cur = conn.cursor()
+    now = datetime.now(timezone.utc)
+    last_cleanup_row = cur.execute(
+        "SELECT value FROM meta WHERE key=?",
+        (ASSIGNMENT_CLEANUP_KEY,),
+    ).fetchone()
+    if last_cleanup_row:
+        try:
+            last_cleanup = datetime.fromisoformat(last_cleanup_row["value"])
+        except (TypeError, ValueError):
+            pass
+        else:
+            if last_cleanup.tzinfo is None:
+                last_cleanup = last_cleanup.replace(tzinfo=timezone.utc)
+            if now - last_cleanup < ASSIGNMENT_CLEANUP_INTERVAL:
+                return False
+    release_incomplete_assignments(existing=conn)
+    retryable_execute(
+        cur,
+        """
+        INSERT INTO meta (key, value)
+        VALUES (?, ?)
+        ON CONFLICT(key) DO UPDATE SET value=excluded.value
+        """,
+        (ASSIGNMENT_CLEANUP_KEY, now.isoformat()),
+    )
+    return True
+
+
+def _assign_discovery(cur) -> dict | None:
+    assigned = retryable_execute(
+        cur,
+        """
+        WITH candidate AS (
+            SELECT steamAccountId, depth
+            FROM players
+            WHERE hero_done=1
+              AND discover_done=0
+              AND assigned_to IS NULL
+            ORDER BY COALESCE(depth, 0) ASC, steamAccountId ASC
+            LIMIT 1
+        )
+        UPDATE players
+        SET assigned_to='discover',
+            assigned_at=CURRENT_TIMESTAMP
+        WHERE steamAccountId IN (SELECT steamAccountId FROM candidate)
+          AND assigned_to IS NULL
+        RETURNING steamAccountId, depth
+        """,
+    ).fetchone()
+    if not assigned:
+        assigned = retryable_execute(
+            cur,
+            """
+            WITH candidate AS (
+                SELECT steamAccountId, depth
+                FROM players
+                WHERE hero_done=1
+                  AND discover_done=0
+                  AND assigned_to='discover'
+                ORDER BY COALESCE(depth, 0) ASC, steamAccountId ASC
+                LIMIT 1
+            )
+            UPDATE players
+            SET assigned_to='discover',
+                assigned_at=CURRENT_TIMESTAMP
+            WHERE steamAccountId IN (SELECT steamAccountId FROM candidate)
+              AND assigned_to='discover'
+            RETURNING steamAccountId, depth
+            """,
+        ).fetchone()
+    if not assigned:
+        return None
+    depth_value = assigned["depth"]
+    return {
+        "type": "discover_matches",
+        "steamAccountId": int(assigned["steamAccountId"]),
+        "depth": int(depth_value) if depth_value is not None else 0,
+    }
+
+
+def _restart_discovery_cycle(cur) -> bool:
+    retryable_execute(
+        cur,
+        """
+        UPDATE players
+        SET discover_done=0,
+            depth=CASE WHEN depth=0 THEN 0 ELSE NULL END,
+            assigned_at=CASE WHEN assigned_to='discover' THEN NULL ELSE assigned_at END,
+            assigned_to=CASE WHEN assigned_to='discover' THEN NULL ELSE assigned_to END
+        """,
+    )
+    return True
+
+
+def assign_next_task(*, run_cleanup: bool = True) -> dict | None:
+    """Select the next task to hand to a worker."""
+    task_payload: dict | None = None
+    should_checkpoint = False
+
+    with db_connection(write=True) as conn:
+        if run_cleanup:
+            maybe_run_assignment_cleanup(conn)
+        cur = conn.cursor()
+
+        def callback(next_count: int) -> Tuple[dict | None, bool]:
+            refresh_due = next_count % 10 == 0
+            discovery_due = next_count % 100 == 0
+            should_truncate_wal = False
+            candidate_payload = None
+
+            if discovery_due:
+                candidate_payload = _assign_discovery(cur)
+                if candidate_payload is None and _restart_discovery_cycle(cur):
+                    should_truncate_wal = True
+                    candidate_payload = _assign_discovery(cur)
+
+            if candidate_payload is None and refresh_due:
+                assigned_row = retryable_execute(
+                    cur,
+                    """
+                    WITH candidate AS (
+                        SELECT steamAccountId
+                        FROM players
+                        WHERE hero_done=1
+                          AND assigned_to IS NULL
+                        ORDER BY COALESCE(hero_refreshed_at, '1970-01-01') ASC,
+                                 steamAccountId ASC
+                        LIMIT 1
+                    )
+                    UPDATE players
+                    SET hero_done=0,
+                        assigned_to='hero',
+                        assigned_at=CURRENT_TIMESTAMP
+                    WHERE steamAccountId IN (SELECT steamAccountId FROM candidate)
+                      AND hero_done=1
+                      AND assigned_to IS NULL
+                    RETURNING steamAccountId
+                    """,
+                ).fetchone()
+                if assigned_row:
+                    candidate_payload = {
+                        "type": "fetch_hero_stats",
+                        "steamAccountId": int(assigned_row["steamAccountId"]),
+                    }
+
+            if candidate_payload is None:
+                assigned_row = retryable_execute(
+                    cur,
+                    """
+                    WITH candidate AS (
+                        SELECT steamAccountId
+                        FROM players
+                        WHERE hero_done=0
+                          AND assigned_to IS NULL
+                        ORDER BY COALESCE(depth, 0) ASC, steamAccountId ASC
+                        LIMIT 1
+                    )
+                    UPDATE players
+                    SET assigned_to='hero',
+                        assigned_at=CURRENT_TIMESTAMP
+                    WHERE steamAccountId IN (SELECT steamAccountId FROM candidate)
+                      AND hero_done=0
+                      AND assigned_to IS NULL
+                    RETURNING steamAccountId
+                    """,
+                ).fetchone()
+                if assigned_row:
+                    candidate_payload = {
+                        "type": "fetch_hero_stats",
+                        "steamAccountId": int(assigned_row["steamAccountId"]),
+                    }
+
+            if candidate_payload is None:
+                hero_pending = cur.execute(
+                    "SELECT 1 FROM players WHERE hero_done=0 LIMIT 1"
+                ).fetchone()
+                if not hero_pending and not discovery_due:
+                    candidate_payload = _assign_discovery(cur)
+
+            return candidate_payload, should_truncate_wal
+
+        task_payload, should_checkpoint = _with_counter(cur, callback)
+
+    if should_checkpoint:
+        with db_connection(write=True) as checkpoint_conn:
+            retryable_execute(
+                checkpoint_conn,
+                "PRAGMA wal_checkpoint(TRUNCATE);",
+            )
+
+    return task_payload
+
+
+def _with_counter(cur, callback: Callable[[int], Tuple[dict | None, bool]]) -> tuple[dict | None, bool]:
+    counter_row = cur.execute(
+        "SELECT value FROM meta WHERE key=?",
+        ("task_assignment_counter",),
+    ).fetchone()
+    try:
+        current_count = int(counter_row["value"]) if counter_row else 0
+    except (TypeError, ValueError):
+        current_count = 0
+
+    loop_count = current_count
+    should_checkpoint = False
+    task_payload: dict | None = None
+
+    while True:
+        next_count = loop_count + 1
+        refresh_due = next_count % 10 == 0
+        discovery_due = next_count % 100 == 0
+        checkpoint_due = next_count % 10000 == 0
+
+        candidate_payload, should_truncate_wal = callback(next_count)
+        if candidate_payload is not None:
+            task_payload = candidate_payload
+            retryable_execute(
+                cur,
+                """
+                INSERT INTO meta (key, value)
+                VALUES (?, ?)
+                ON CONFLICT(key) DO UPDATE SET value=excluded.value
+                """,
+                ("task_assignment_counter", str(next_count)),
+            )
+            if checkpoint_due or should_truncate_wal:
+                should_checkpoint = True
+            break
+
+        if refresh_due or discovery_due:
+            break
+
+        loop_count = next_count
+
+    return task_payload, should_checkpoint

--- a/stratz_scraper/web/config.py
+++ b/stratz_scraper/web/config.py
@@ -1,0 +1,11 @@
+"""Configuration helpers for the web package."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent
+STATIC_DIR = BASE_DIR / "static"
+TEMPLATE_DIR = BASE_DIR / "templates"
+
+__all__ = ["BASE_DIR", "STATIC_DIR", "TEMPLATE_DIR"]

--- a/stratz_scraper/web/leaderboard.py
+++ b/stratz_scraper/web/leaderboard.py
@@ -1,0 +1,50 @@
+"""Leaderboard helpers."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Tuple
+
+from ..database import db_connection
+from ..heroes import HERO_SLUGS, hero_slug
+
+__all__ = ["fetch_best_payload", "fetch_hero_leaderboard"]
+
+
+def fetch_hero_leaderboard(slug: str) -> Optional[Tuple[str, str, List[dict]]]:
+    normalized = slug.strip().replace(" ", "_").lower()
+    hero_entry = HERO_SLUGS.get(normalized)
+    if not hero_entry:
+        return None
+    hero_id, hero_name = hero_entry
+    with db_connection() as conn:
+        rows = conn.execute(
+            """
+            SELECT steamAccountId, matches, wins
+            FROM hero_stats
+            WHERE heroId=?
+            ORDER BY matches DESC, wins DESC, steamAccountId ASC
+            LIMIT 100
+            """,
+            (hero_id,),
+        ).fetchall()
+    players = [
+        {
+            "steamAccountId": row["steamAccountId"],
+            "matches": row["matches"],
+            "wins": row["wins"],
+        }
+        for row in rows
+    ]
+    return hero_name, normalized, players
+
+
+def fetch_best_payload() -> List[Dict]:
+    with db_connection() as conn:
+        rows = conn.execute("SELECT * FROM best ORDER BY matches DESC").fetchall()
+    payload: List[Dict] = []
+    for row in rows:
+        row_dict = dict(row)
+        name = row_dict.get("hero_name")
+        row_dict["hero_slug"] = hero_slug(name) if isinstance(name, str) else None
+        payload.append(row_dict)
+    return payload

--- a/stratz_scraper/web/progress.py
+++ b/stratz_scraper/web/progress.py
@@ -1,0 +1,25 @@
+"""Progress reporting helpers."""
+
+from __future__ import annotations
+
+from ..database import db_connection
+
+__all__ = ["fetch_progress"]
+
+
+def fetch_progress() -> dict:
+    with db_connection() as conn:
+        total = conn.execute("SELECT COUNT(*) AS c FROM players").fetchone()["c"]
+        hero_done = (
+            conn.execute("SELECT COUNT(*) AS c FROM players WHERE hero_done=1").fetchone()["c"]
+        )
+        discover_done = (
+            conn.execute(
+                "SELECT COUNT(*) AS c FROM players WHERE discover_done=1"
+            ).fetchone()["c"]
+        )
+    return {
+        "players_total": total,
+        "hero_done": hero_done,
+        "discover_done": discover_done,
+    }

--- a/stratz_scraper/web/request_utils.py
+++ b/stratz_scraper/web/request_utils.py
@@ -1,0 +1,31 @@
+"""Utilities for dealing with request metadata."""
+
+from __future__ import annotations
+
+from flask import Request, request
+
+__all__ = ["is_local_request"]
+
+
+def _is_loopback_address(address: str) -> bool:
+    address = (address or "").strip()
+    if not address:
+        return False
+    return address in {"127.0.0.1", "::1"} or address.startswith("127.")
+
+
+def is_local_request(active_request: Request | None = None) -> bool:
+    """Return ``True`` when the incoming request originated from localhost."""
+
+    active_request = active_request or request
+    remote_addr = getattr(active_request, "remote_addr", None)
+    if _is_loopback_address(remote_addr or ""):
+        return True
+
+    access_route = getattr(active_request, "access_route", []) or []
+    for addr in access_route:
+        if _is_loopback_address(addr or ""):
+            return True
+
+    forwarded_for = (active_request.headers.get("X-Forwarded-For", "") if active_request else "").split(",")
+    return any(_is_loopback_address(addr) for addr in forwarded_for)

--- a/stratz_scraper/web/seed.py
+++ b/stratz_scraper/web/seed.py
@@ -1,0 +1,26 @@
+"""Utility helpers for seeding players."""
+
+from __future__ import annotations
+
+from ..database import db_connection, retryable_execute
+
+__all__ = ["seed_players"]
+
+
+def seed_players(start: int, end: int) -> None:
+    with db_connection(write=True) as conn:
+        cur = conn.cursor()
+        for pid in range(start, end + 1):
+            retryable_execute(
+                cur,
+                """
+                INSERT OR IGNORE INTO players (
+                    steamAccountId,
+                    depth,
+                    hero_done,
+                    discover_done
+                )
+                VALUES (?,?,0,0)
+                """,
+                (pid, 0),
+            )

--- a/stratz_scraper/web/submissions.py
+++ b/stratz_scraper/web/submissions.py
@@ -1,0 +1,270 @@
+"""Background submission helpers."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
+from typing import Iterable, Sequence
+
+from ..database import db_connection, retryable_execute, retryable_executemany
+
+BACKGROUND_EXECUTOR = ThreadPoolExecutor(max_workers=4)
+
+__all__ = [
+    "BACKGROUND_EXECUTOR",
+    "process_discover_submission",
+    "process_hero_submission",
+    "record_task_duration",
+    "submit_discover_submission",
+    "submit_hero_submission",
+]
+
+
+def _parse_sqlite_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def record_task_duration(cur, steam_account_id: int, task_type: str, assigned_at_value: str | None) -> float | None:
+    submitted_at = datetime.now(timezone.utc)
+    assigned_at = _parse_sqlite_timestamp(assigned_at_value)
+    duration_seconds = None
+    if assigned_at is not None:
+        duration_seconds = (submitted_at - assigned_at).total_seconds()
+    retryable_execute(
+        cur,
+        """
+        INSERT INTO task_durations (
+            steamAccountId,
+            task_type,
+            assigned_at,
+            submitted_at,
+            duration_seconds
+        ) VALUES (?, ?, ?, ?, ?)
+        """,
+        (
+            steam_account_id,
+            task_type,
+            assigned_at.isoformat() if assigned_at is not None else assigned_at_value,
+            submitted_at.isoformat(),
+            duration_seconds,
+        ),
+    )
+    if duration_seconds is not None:
+        print(
+            f"[task-duration] {task_type} for {steam_account_id} took {duration_seconds:.2f}s",
+            flush=True,
+        )
+    else:
+        print(
+            f"[task-duration] {task_type} for {steam_account_id} has no assignment timestamp",
+            flush=True,
+        )
+    return duration_seconds
+
+
+def _unmark_hero_task(steam_account_id: int) -> None:
+    try:
+        with db_connection(write=True) as conn:
+            cur = conn.cursor()
+            retryable_execute(
+                cur,
+                """
+                UPDATE players
+                SET hero_done=0,
+                    hero_refreshed_at=NULL,
+                    assigned_to=NULL,
+                    assigned_at=NULL
+                WHERE steamAccountId=?
+                """,
+                (steam_account_id,),
+            )
+    except Exception:
+        import traceback
+
+        traceback.print_exc()
+
+
+def _unmark_discover_task(steam_account_id: int) -> None:
+    try:
+        with db_connection(write=True) as conn:
+            cur = conn.cursor()
+            retryable_execute(
+                cur,
+                """
+                UPDATE players
+                SET discover_done=0,
+                    assigned_to=NULL,
+                    assigned_at=NULL
+                WHERE steamAccountId=?
+                """,
+                (steam_account_id,),
+            )
+    except Exception:
+        import traceback
+
+        traceback.print_exc()
+
+
+def process_hero_submission(
+    steam_account_id: int,
+    hero_stats_rows: Sequence[tuple[int, int, int, int]],
+    best_rows: Sequence[tuple[int, str, int, int, int]],
+    assigned_at_value: str | None,
+) -> None:
+    try:
+        with db_connection(write=True) as conn:
+            cur = conn.cursor()
+            retryable_executemany(
+                cur,
+                """
+                INSERT INTO hero_stats (steamAccountId, heroId, matches, wins)
+                VALUES (?,?,?,?)
+                ON CONFLICT(steamAccountId, heroId) DO UPDATE SET
+                    matches = CASE
+                        WHEN excluded.matches > hero_stats.matches
+                        THEN excluded.matches
+                        ELSE hero_stats.matches
+                    END,
+                    wins = CASE
+                        WHEN excluded.matches > hero_stats.matches
+                        THEN excluded.wins
+                        ELSE hero_stats.wins
+                    END
+                """,
+                hero_stats_rows or [],
+            )
+            if best_rows:
+                retryable_executemany(
+                    cur,
+                    """
+                    INSERT INTO best (hero_id, hero_name, player_id, matches, wins)
+                    VALUES (?,?,?,?,?)
+                    ON CONFLICT(hero_id) DO UPDATE SET
+                        matches=excluded.matches,
+                        wins=excluded.wins,
+                        player_id=excluded.player_id
+                    WHERE excluded.matches > best.matches
+                    """,
+                    best_rows,
+                )
+            retryable_execute(
+                cur,
+                """
+                UPDATE players
+                SET hero_done=1,
+                    hero_refreshed_at=CURRENT_TIMESTAMP
+                WHERE steamAccountId=?
+                """,
+                (steam_account_id,),
+            )
+            record_task_duration(
+                cur,
+                steam_account_id,
+                "fetch_hero_stats",
+                assigned_at_value,
+            )
+    except Exception:
+        import traceback
+
+        print(
+            f"[submit-background] failed to process hero stats for {steam_account_id}",
+            flush=True,
+        )
+        traceback.print_exc()
+        _unmark_hero_task(steam_account_id)
+
+
+def process_discover_submission(
+    steam_account_id: int,
+    discovered_ids: Iterable[int],
+    next_depth_value: int,
+    assigned_at_value: str | None,
+) -> None:
+    try:
+        with db_connection(write=True) as conn:
+            cur = conn.cursor()
+            child_rows = [
+                (new_id, next_depth_value)
+                for new_id in discovered_ids
+                if new_id != steam_account_id
+            ]
+            if child_rows:
+                retryable_executemany(
+                    cur,
+                    """
+                    INSERT INTO players (
+                        steamAccountId,
+                        depth,
+                        hero_done,
+                        discover_done
+                    )
+                    VALUES (?,?,0,0)
+                    ON CONFLICT(steamAccountId) DO UPDATE SET
+                        depth=excluded.depth
+                    """,
+                    child_rows,
+                )
+            retryable_execute(
+                cur,
+                """
+                UPDATE players
+                SET discover_done=1,
+                    assigned_to=NULL,
+                    assigned_at=NULL
+                WHERE steamAccountId=?
+                """,
+                (steam_account_id,),
+            )
+            record_task_duration(
+                cur,
+                steam_account_id,
+                "discover_matches",
+                assigned_at_value,
+            )
+    except Exception:
+        import traceback
+
+        print(
+            f"[submit-background] failed to process discovery for {steam_account_id}",
+            flush=True,
+        )
+        traceback.print_exc()
+        _unmark_discover_task(steam_account_id)
+
+
+def submit_hero_submission(
+    steam_account_id: int,
+    hero_stats_rows: Sequence[tuple[int, int, int, int]],
+    best_rows: Sequence[tuple[int, str, int, int, int]],
+    assigned_at_value: str | None,
+) -> None:
+    BACKGROUND_EXECUTOR.submit(
+        process_hero_submission,
+        steam_account_id,
+        hero_stats_rows,
+        best_rows,
+        assigned_at_value,
+    )
+
+
+def submit_discover_submission(
+    steam_account_id: int,
+    discovered_ids: Iterable[int],
+    next_depth_value: int,
+    assigned_at_value: str | None,
+) -> None:
+    BACKGROUND_EXECUTOR.submit(
+        process_discover_submission,
+        steam_account_id,
+        tuple(discovered_ids),
+        next_depth_value,
+        assigned_at_value,
+    )

--- a/stratz_scraper/web/tasks.py
+++ b/stratz_scraper/web/tasks.py
@@ -1,0 +1,73 @@
+"""Task management helpers."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from ..database import db_connection, retryable_execute
+
+__all__ = ["reset_player_task"]
+
+
+def _reset_hero_task(cur, steam_account_id: int) -> int:
+    has_existing_stats = cur.execute(
+        "SELECT 1 FROM hero_stats WHERE steamAccountId=? LIMIT 1",
+        (steam_account_id,),
+    ).fetchone()
+    hero_done_value = 1 if has_existing_stats else 0
+    update_cursor = retryable_execute(
+        cur,
+        """
+        UPDATE players
+        SET hero_done=?,
+            hero_refreshed_at=CASE WHEN ? THEN hero_refreshed_at ELSE NULL END,
+            assigned_to=NULL,
+            assigned_at=NULL
+        WHERE steamAccountId=?
+        """,
+        (hero_done_value, hero_done_value, steam_account_id),
+    )
+    return update_cursor.rowcount if update_cursor.rowcount is not None else 0
+
+
+def _reset_discover_task(cur, steam_account_id: int) -> int:
+    update_cursor = retryable_execute(
+        cur,
+        """
+        UPDATE players
+        SET discover_done=1,
+            assigned_to=NULL,
+            assigned_at=NULL
+        WHERE steamAccountId=?
+        """,
+        (steam_account_id,),
+    )
+    return update_cursor.rowcount if update_cursor.rowcount is not None else 0
+
+
+def _reset_generic_task(cur, steam_account_id: int) -> int:
+    update_cursor = retryable_execute(
+        cur,
+        """
+        UPDATE players
+        SET assigned_to=NULL,
+            assigned_at=NULL
+        WHERE steamAccountId=?
+        """,
+        (steam_account_id,),
+    )
+    return update_cursor.rowcount if update_cursor.rowcount is not None else 0
+
+
+def reset_player_task(steam_account_id: int, task_type: Optional[str]) -> bool:
+    """Reset the task assignment for ``steam_account_id``."""
+
+    with db_connection(write=True) as conn:
+        cur = conn.cursor()
+        if task_type == "fetch_hero_stats":
+            updated = _reset_hero_task(cur, steam_account_id)
+        elif task_type == "discover_matches":
+            updated = _reset_discover_task(cur, steam_account_id)
+        else:
+            updated = _reset_generic_task(cur, steam_account_id)
+    return updated > 0


### PR DESCRIPTION
## Summary
- extract configuration, request, and database helpers into dedicated modules
- split task assignment, submissions, leaderboards, seeding, and progress logic into focused services
- streamline the Flask application factory to consume the new helpers and keep routes focused on HTTP handling

## Testing
- python -m compileall stratz_scraper

------
https://chatgpt.com/codex/tasks/task_e_68d423489a048324b60e693d87d4fd1d