### PR TITLE
Add leaderboard index for hero stats

### DIFF
--- a/stratz_scraper/database.py
+++ b/stratz_scraper/database.py
@@ -229,6 +229,13 @@ def ensure_indexes(*, lock_acquired: bool = False) -> None:
                         assigned_to,
                         assigned_at
                     );
+                CREATE INDEX IF NOT EXISTS idx_hero_stats_leaderboard
+                    ON hero_stats (
+                        heroId,
+                        matches DESC,
+                        wins DESC,
+                        steamAccountId
+                    );
                 """
             )
     _INDEXES_ENSURED = True


### PR DESCRIPTION
## Summary
- add a composite index on hero_stats to optimize leaderboard lookups

## Testing
- python -m compileall stratz_scraper

------
https://chatgpt.com/codex/tasks/task_e_68d5010b964483249f3ea0eee8f89fdb