### PR TITLE
Track discovery counts and prioritize busy players

### DIFF
--- a/stratz_scraper/web/assignment.py
+++ b/stratz_scraper/web/assignment.py
@@ -111,6 +111,7 @@ def _restart_discovery_cycle(cur) -> bool:
         """
         UPDATE players
         SET discover_done=0,
+            seen_count=0,
             depth=CASE WHEN depth=0 THEN 0 ELSE NULL END,
             assigned_at=CASE WHEN assigned_to='discover' THEN NULL ELSE assigned_at END,
             assigned_to=CASE WHEN assigned_to='discover' THEN NULL ELSE assigned_to END

--- a/stratz_scraper/web/assignment.py
+++ b/stratz_scraper/web/assignment.py
@@ -153,8 +153,8 @@ def assign_next_task(*, run_cleanup: bool = True) -> dict | None:
                         FROM players
                         WHERE hero_done=1
                           AND assigned_to IS NULL
-                        ORDER BY seen_count DESC,
-                                 COALESCE(hero_refreshed_at, '1970-01-01') ASC,
+                        ORDER BY COALESCE(hero_refreshed_at, '1970-01-01') ASC,
+                                 seen_count DESC,
                                  steamAccountId ASC
                         LIMIT 1
                     )

--- a/stratz_scraper/web/assignment.py
+++ b/stratz_scraper/web/assignment.py
@@ -63,7 +63,7 @@ def _assign_discovery(cur) -> dict | None:
             WHERE hero_done=1
               AND discover_done=0
               AND assigned_to IS NULL
-            ORDER BY COALESCE(depth, 0) ASC, steamAccountId ASC
+            ORDER BY seen_count DESC, COALESCE(depth, 0) ASC, steamAccountId ASC
             LIMIT 1
         )
         UPDATE players
@@ -84,7 +84,7 @@ def _assign_discovery(cur) -> dict | None:
                 WHERE hero_done=1
                   AND discover_done=0
                   AND assigned_to='discover'
-                ORDER BY COALESCE(depth, 0) ASC, steamAccountId ASC
+                ORDER BY seen_count DESC, COALESCE(depth, 0) ASC, steamAccountId ASC
                 LIMIT 1
             )
             UPDATE players
@@ -150,7 +150,8 @@ def assign_next_task(*, run_cleanup: bool = True) -> dict | None:
                         FROM players
                         WHERE hero_done=1
                           AND assigned_to IS NULL
-                        ORDER BY COALESCE(hero_refreshed_at, '1970-01-01') ASC,
+                        ORDER BY seen_count DESC,
+                                 COALESCE(hero_refreshed_at, '1970-01-01') ASC,
                                  steamAccountId ASC
                         LIMIT 1
                     )
@@ -179,7 +180,7 @@ def assign_next_task(*, run_cleanup: bool = True) -> dict | None:
                         FROM players
                         WHERE hero_done=0
                           AND assigned_to IS NULL
-                        ORDER BY COALESCE(depth, 0) ASC, steamAccountId ASC
+                        ORDER BY seen_count DESC, COALESCE(depth, 0) ASC, steamAccountId ASC
                         LIMIT 1
                     )
                     UPDATE players

--- a/stratz_scraper/web/static/js/app.js
+++ b/stratz_scraper/web/static/js/app.js
@@ -983,7 +983,7 @@ async function discoverMatches(playerId, token, { take = 100, skip = 0 } = {}) {
     }
   `;
 
-  const discovered = new Set();
+  const discovered = new Map();
   let nextSkip = startingSkip;
   let tokenIndex = 0;
 
@@ -1013,7 +1013,8 @@ async function discoverMatches(playerId, token, { take = 100, skip = 0 } = {}) {
               ? Number.parseInt(rawId, 10)
               : null;
         if (Number.isFinite(id) && id !== playerId) {
-          discovered.add(id);
+          const previous = discovered.get(id) ?? 0;
+          discovered.set(id, previous + 1);
         }
       });
     });
@@ -1026,7 +1027,10 @@ async function discoverMatches(playerId, token, { take = 100, skip = 0 } = {}) {
     tokenIndex = (usedIndex + 1) % tokens.length;
   }
 
-  return Array.from(discovered);
+  return Array.from(discovered, ([steamAccountId, count]) => ({
+    steamAccountId,
+    count,
+  }));
 }
 
 async function submitHeroStats(playerId, heroes) {

--- a/stratz_scraper/web/submissions.py
+++ b/stratz_scraper/web/submissions.py
@@ -209,7 +209,11 @@ def process_discover_submission(
                     )
                     VALUES (?,?,0,0,?)
                     ON CONFLICT(steamAccountId) DO UPDATE SET
-                        depth=excluded.depth,
+                        depth=CASE
+                            WHEN players.depth IS NULL THEN excluded.depth
+                            WHEN excluded.depth < players.depth THEN excluded.depth
+                            ELSE players.depth
+                        END,
                         seen_count=players.seen_count + excluded.seen_count
                     """,
                     child_rows,

--- a/stratz_scraper/web/tasks.py
+++ b/stratz_scraper/web/tasks.py
@@ -35,7 +35,7 @@ def _reset_discover_task(cur, steam_account_id: int) -> int:
         cur,
         """
         UPDATE players
-        SET discover_done=1,
+        SET discover_done=0,
             assigned_to=NULL,
             assigned_at=NULL
         WHERE steamAccountId=?


### PR DESCRIPTION
## Summary
- capture how many times each discovered player appears in discovery tasks and send the counts to the server
- aggregate and persist discovery counts in the database while updating assignment queries to prioritize frequently seen players
- add schema/index migrations so existing data can track and use the new discovery counts

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d64a9ea56883249a999630388bdeb7