### PR TITLE
Fix discover task reset flag

### DIFF
--- a/stratz_scraper/web/tasks.py
+++ b/stratz_scraper/web/tasks.py
@@ -35,7 +35,7 @@ def _reset_discover_task(cur, steam_account_id: int) -> int:
         cur,
         """
         UPDATE players
-        SET discover_done=1,
+        SET discover_done=0,
             assigned_to=NULL,
             assigned_at=NULL
         WHERE steamAccountId=?


### PR DESCRIPTION
## Summary
- ensure resetting a `discover_matches` task clears the `discover_done` flag so the task can be reassigned

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d674a3dc9c83249e22e815ecc68e08