### PR TITLE
Update discover depth conflict handling

### DIFF
--- a/stratz_scraper/web/submissions.py
+++ b/stratz_scraper/web/submissions.py
@@ -209,7 +209,11 @@ def process_discover_submission(
                     )
                     VALUES (?,?,0,0,?)
                     ON CONFLICT(steamAccountId) DO UPDATE SET
-                        depth=excluded.depth,
+                        depth=CASE
+                            WHEN players.depth IS NULL THEN excluded.depth
+                            WHEN excluded.depth < players.depth THEN excluded.depth
+                            ELSE players.depth
+                        END,
                         seen_count=players.seen_count + excluded.seen_count
                     """,
                     child_rows,


### PR DESCRIPTION
## Summary
- prevent discovered player inserts from overwriting depth with a greater value

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d69afe1fb08324b6549fcd9cfd3153