### PR TITLE
Fix hero refresh rotation

### DIFF
--- a/stratz_scraper/web/assignment.py
+++ b/stratz_scraper/web/assignment.py
@@ -153,8 +153,8 @@ def assign_next_task(*, run_cleanup: bool = True) -> dict | None:
                         FROM players
                         WHERE hero_done=1
                           AND assigned_to IS NULL
-                        ORDER BY seen_count DESC,
-                                 COALESCE(hero_refreshed_at, '1970-01-01') ASC,
+                        ORDER BY COALESCE(hero_refreshed_at, '1970-01-01') ASC,
+                                 seen_count DESC,
                                  steamAccountId ASC
                         LIMIT 1
                     )


### PR DESCRIPTION
## Summary
- change the hero refresh candidate ordering to prioritize the oldest refreshed player before seen counts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6b0bd5fa08324b895501ae272bb1e