### PR TITLE
Remove STRATZ_API User-Agent header from frontend fetches

### DIFF
--- a/stratz_scraper/web/static/js/app.js
+++ b/stratz_scraper/web/static/js/app.js
@@ -319,7 +319,6 @@ async function executeStratzQuery(query, variables, token) {
     headers: {
       Authorization: `Bearer ${activeToken}`,
       "Content-Type": "application/json",
-      "User-Agent": "STRATZ_API",
     },
     body: JSON.stringify({ query, variables }),
   });
@@ -893,7 +892,6 @@ async function fetchPlayerHeroes(playerId, token) {
     headers: {
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
-      'User-Agent': 'STRATZ_API',
     },
     body: JSON.stringify({ query, variables: { id: playerId } }),
   });


### PR DESCRIPTION
## Summary
- remove the custom STRATZ_API User-Agent header from frontend GraphQL requests so that only authorization and content type are sent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d70c6cc71483249cd287386db022ea