### PR TITLE
Add PyQt desktop client and CI build workflow

### DIFF
--- a/.github/workflows/build-client.yml
+++ b/.github/workflows/build-client.yml
@@ -1,0 +1,38 @@
+name: Build PyQt Client
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+
+jobs:
+  build-client:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-client.txt pyinstaller
+
+      - name: Build executable
+        shell: pwsh
+        run: |
+          if (Test-Path dist) { Remove-Item -Recurse -Force dist }
+          if (Test-Path build) { Remove-Item -Recurse -Force build }
+          pyinstaller --noconfirm --windowed --name StratzScraperClient stratz_scraper/client/__main__.py
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: StratzScraperClient-windows
+          path: dist/StratzScraperClient

--- a/.github/workflows/build-client.yml
+++ b/.github/workflows/build-client.yml
@@ -29,10 +29,10 @@ jobs:
         run: |
           if (Test-Path dist) { Remove-Item -Recurse -Force dist }
           if (Test-Path build) { Remove-Item -Recurse -Force build }
-          pyinstaller --noconfirm --windowed --name StratzScraperClient stratz_scraper/client/__main__.py
+          pyinstaller --noconfirm --windowed --onefile --name StratzScraperClient stratz_scraper/client/__main__.py
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: StratzScraperClient-windows
-          path: dist/StratzScraperClient
+          path: dist/StratzScraperClient.exe

--- a/.github/workflows/build-client.yml
+++ b/.github/workflows/build-client.yml
@@ -18,6 +18,14 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-client.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Install dependencies
         shell: pwsh
         run: |

--- a/.github/workflows/build-client.yml
+++ b/.github/workflows/build-client.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           if (Test-Path dist) { Remove-Item -Recurse -Force dist }
           if (Test-Path build) { Remove-Item -Recurse -Force build }
-          pyinstaller --noconfirm --windowed --onefile --name StratzScraperClient stratz_scraper/client/__main__.py
+          pyinstaller --noconfirm --onefile --name StratzScraperClient stratz_scraper/client/__main__.py
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,7 @@
 !stratz_scraper/
 !stratz_scraper/**
 !**/*.py
+!.github/
+!.github/**
+!requirements-client.txt
 **/__pycache__

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ A cross-platform PyQt client replaces the previous browser interface. The deskto
 
 ### Running the client
 
-1. Install the client dependencies (Selenium is included so the worker can mirror your installed browser headers):
+1. Install the client dependencies:
 
    ```bash
    python -m pip install -r requirements-client.txt
@@ -78,7 +78,7 @@ A cross-platform PyQt client replaces the previous browser interface. The deskto
 
 3. Enter your Stratz API tokens, optionally set request limits, and press **Start**. Each token spawns an isolated worker process that communicates with the Flask backend and the Stratz GraphQL API without blocking the interface.
 
-   On startup the worker spins up Selenium WebDriver, probing Chrome, Edge, and Firefox until it finds an installed browser. The headers observed from that browser are then replayed for every Stratz GraphQL call, which keeps the API from rejecting valid tokens with `403 Forbidden` responses. If no compatible browser is found the worker falls back to a bundled Chrome-like profile and logs the failure so you can diagnose the missing driver.
+   The worker replays a bundled Firefox-style header profile for every Stratz GraphQL call so the API sees consistent browser traffic. Tokens and request limits are still isolated per process, keeping concurrency high without blocking the UI.
 
 Additional toolbar buttons let you import or export the complete token list to JSON, making it easy to move configurations between machines.
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ A cross-platform PyQt client replaces the previous browser interface. The deskto
 
 ### Running the client
 
-1. Install the client dependencies:
+1. Install the client dependencies (Selenium is included so the worker can mirror your installed browser headers):
 
    ```bash
    python -m pip install -r requirements-client.txt
@@ -77,6 +77,8 @@ A cross-platform PyQt client replaces the previous browser interface. The deskto
    ```
 
 3. Enter your Stratz API tokens, optionally set request limits, and press **Start**. Each token spawns an isolated worker process that communicates with the Flask backend and the Stratz GraphQL API without blocking the interface.
+
+   On startup the worker spins up Selenium WebDriver, probing Chrome, Edge, and Firefox until it finds an installed browser. The headers observed from that browser are then replayed for every Stratz GraphQL call, which keeps the API from rejecting valid tokens with `403 Forbidden` responses. If no compatible browser is found the worker falls back to a bundled Chrome-like profile and logs the failure so you can diagnose the missing driver.
 
 Additional toolbar buttons let you import or export the complete token list to JSON, making it easy to move configurations between machines.
 

--- a/README.md
+++ b/README.md
@@ -78,13 +78,15 @@ A cross-platform PyQt client replaces the previous browser interface. The deskto
 
 3. Enter your Stratz API tokens, optionally set request limits, and press **Start**. Each token spawns an isolated worker process that communicates with the Flask backend and the Stratz GraphQL API without blocking the interface.
 
+Additional toolbar buttons let you import or export the complete token list to JSON, making it easy to move configurations between machines.
+
 ### Building a Windows executable
 
 The repository ships with a GitHub Actions workflow (`build-client`) that packages the client with PyInstaller on `windows-latest`. To build locally run:
 
 ```bash
 python -m pip install pyinstaller
-pyinstaller --noconfirm --windowed --name StratzScraperClient stratz_scraper/client/__main__.py
+pyinstaller --noconfirm --windowed --onefile --name StratzScraperClient stratz_scraper/client/__main__.py
 ```
 
 The workflow output is published as the `StratzScraperClient-windows` artifact on every push and pull request.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,37 @@ python app.py
 
 The app listens on `0.0.0.0:80`. Ensure the process has permission to create `dota.db`; on first boot it will populate the schema and seed the root account automatically. When deploying behind a proxy, forward the original client IP so the `/seed` endpoint remains restricted to local administrators via `is_local_request`.【F:app.py†L1-L7】【F:stratz_scraper/web/app.py†L1-L434】
 
+## Windows Desktop Client
+
+A cross-platform PyQt client replaces the previous browser interface. The desktop application uses multiprocessing to run each Stratz token in its own process, mirroring the concurrency guarantees of the former web workers while keeping the UI responsive.
+
+### Running the client
+
+1. Install the client dependencies:
+
+   ```bash
+   python -m pip install -r requirements-client.txt
+   ```
+
+2. Launch the UI:
+
+   ```bash
+   python -m stratz_scraper.client
+   ```
+
+3. Enter your Stratz API tokens, optionally set request limits, and press **Start**. Each token spawns an isolated worker process that communicates with the Flask backend and the Stratz GraphQL API without blocking the interface.
+
+### Building a Windows executable
+
+The repository ships with a GitHub Actions workflow (`build-client`) that packages the client with PyInstaller on `windows-latest`. To build locally run:
+
+```bash
+python -m pip install pyinstaller
+pyinstaller --noconfirm --windowed --name StratzScraperClient stratz_scraper/client/__main__.py
+```
+
+The workflow output is published as the `StratzScraperClient-windows` artifact on every push and pull request.
+
 ## Database Schema Reference
 
 | Table | Purpose | Key Columns |

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,0 +1,2 @@
+PyQt6>=6.5
+requests>=2.31

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,2 +1,3 @@
 PyQt6>=6.5
 requests>=2.31
+selenium>=4.18

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,3 +1,2 @@
 PyQt6>=6.5
 requests>=2.31
-selenium>=4.18

--- a/stratz_scraper/__init__.py
+++ b/stratz_scraper/__init__.py
@@ -1,3 +1,19 @@
-from .web.app import create_app
+from __future__ import annotations
+
+from typing import Any
+
+
+def create_app(*args: Any, **kwargs: Any):
+    """Return a configured Flask application instance.
+
+    The import is deferred so environments that only need the desktop client do not have
+    to install the Flask backend's dependencies. This keeps ``stratz_scraper`` importable
+    without Flask while preserving the public API used by ``app.py``.
+    """
+
+    from .web.app import create_app as _create_app
+
+    return _create_app(*args, **kwargs)
+
 
 __all__ = ["create_app"]

--- a/stratz_scraper/client/__init__.py
+++ b/stratz_scraper/client/__init__.py
@@ -1,0 +1,5 @@
+"""PyQt client application for the Stratz distributed scraper."""
+
+from .application import main
+
+__all__ = ["main"]

--- a/stratz_scraper/client/__main__.py
+++ b/stratz_scraper/client/__main__.py
@@ -1,8 +1,36 @@
 """Entry point for launching the PyQt client."""
+from __future__ import annotations
 
 import sys
+from pathlib import Path
 
-from .application import main
+
+def _resolve_main():
+    """Import and return the :func:`main` callable.
+
+    When this module is executed as a script (``python stratz_scraper/client/__main__.py``)
+    Python does not treat ``stratz_scraper`` as a package, so relative imports fail with
+    ``ImportError: attempted relative import with no known parent package``. To keep the
+    launch command flexible we detect that situation, ensure the repository root is on
+    ``sys.path``, and then perform an absolute import instead.
+    """
+
+    if __package__:
+        from .application import main as entrypoint
+        return entrypoint
+
+    repo_root = Path(__file__).resolve().parents[2]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    from stratz_scraper.client.application import main as entrypoint
+    return entrypoint
+
+
+def _run() -> int:
+    main = _resolve_main()
+    return main()
+
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(_run())

--- a/stratz_scraper/client/__main__.py
+++ b/stratz_scraper/client/__main__.py
@@ -1,0 +1,8 @@
+"""Entry point for launching the PyQt client."""
+
+import sys
+
+from .application import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/stratz_scraper/client/application.py
+++ b/stratz_scraper/client/application.py
@@ -1,0 +1,776 @@
+"""PyQt application replicating the web interface for the Stratz scraper."""
+from __future__ import annotations
+
+import json
+import os
+import queue
+import sys
+from dataclasses import dataclass, field
+from functools import partial
+from multiprocessing import Event, Process, Queue as MPQueue, freeze_support
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from PyQt6.QtCore import QTimer
+from PyQt6.QtGui import QAction, QTextCursor
+from PyQt6.QtWidgets import (
+    QApplication,
+    QFileDialog,
+    QGroupBox,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QLineEdit,
+    QMainWindow,
+    QMenu,
+    QMenuBar,
+    QMessageBox,
+    QPushButton,
+    QSpinBox,
+    QTableWidget,
+    QTableWidgetItem,
+    QTabWidget,
+    QPlainTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from .worker import WorkerConfig, worker_entry
+
+TOKENS_FILE = Path.home() / ".stratz_scraper_tokens.json"
+LOG_MAX_ENTRIES = 200
+
+
+@dataclass
+class TokenStatus:
+    running: bool = False
+    backoff_ms: int = 10_000
+    requests_remaining: Optional[int] = None
+    completed_tasks: int = 0
+    runtime_ms: float = 0.0
+    average_task_ms: Optional[float] = None
+    tasks_per_day: Optional[float] = None
+    stop_requested: bool = False
+    timestamp_ms: Optional[int] = None
+
+
+@dataclass
+class TokenWidgets:
+    token_edit: QLineEdit
+    max_edit: QSpinBox
+    status_label: QLabel
+    backoff_label: QLabel
+    requests_label: QLabel
+    average_label: QLabel
+    projection_label: QLabel
+    start_button: QPushButton
+    stop_button: QPushButton
+    remove_button: QPushButton
+
+
+@dataclass
+class TokenItem:
+    identifier: str
+    value: str = ""
+    max_requests: Optional[int] = None
+    status: TokenStatus = field(default_factory=TokenStatus)
+    widgets: Optional[TokenWidgets] = None
+    worker: Optional[Process] = None
+    stop_event: Optional[Event] = None
+    log_entries: List[str] = field(default_factory=list)
+
+    @property
+    def running(self) -> bool:
+        return bool(self.status.running)
+
+
+class TokenTable(QTableWidget):
+    def __init__(self) -> None:
+        super().__init__(0, 9)
+        self.setHorizontalHeaderLabels(
+            [
+                "Token",
+                "Max Requests",
+                "Status",
+                "Backoff",
+                "Requests Left",
+                "Avg Task",
+                "24h Projection",
+                "Start",
+                "Stop",
+            ]
+        )
+        header = self.horizontalHeader()
+        header.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
+        header.setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)
+        for i in range(2, 7):
+            header.setSectionResizeMode(i, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(7, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(8, QHeaderView.ResizeMode.ResizeToContents)
+        self.verticalHeader().setVisible(False)
+        self.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
+        self.setSelectionMode(QTableWidget.SelectionMode.SingleSelection)
+        self.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+
+
+class ClientWindow(QMainWindow):
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Stratz Scraper Client")
+        self.resize(1200, 800)
+
+        self.message_queue: MPQueue = MPQueue()
+        self.tokens: List[TokenItem] = []
+        self.token_counter = 1
+
+        self._setup_menu()
+        self._init_ui()
+        self._load_tokens()
+        self._update_controls()
+        self._update_global_metrics()
+
+        self.queue_timer = QTimer(self)
+        self.queue_timer.timeout.connect(self.process_worker_messages)
+        self.queue_timer.start(200)
+
+        self.monitor_timer = QTimer(self)
+        self.monitor_timer.timeout.connect(self._cleanup_workers)
+        self.monitor_timer.start(1000)
+
+    # ----- UI setup -----
+    def _setup_menu(self) -> None:
+        menu_bar = QMenuBar(self)
+        file_menu = QMenu("File", self)
+        import_action = QAction("Import Tokens…", self)
+        import_action.triggered.connect(self.import_tokens)
+        export_action = QAction("Export Tokens…", self)
+        export_action.triggered.connect(self.export_tokens)
+        file_menu.addAction(import_action)
+        file_menu.addAction(export_action)
+        menu_bar.addMenu(file_menu)
+        self.setMenuBar(menu_bar)
+
+    def _init_ui(self) -> None:
+        central = QWidget(self)
+        layout = QVBoxLayout(central)
+
+        server_layout = QHBoxLayout()
+        server_label = QLabel("Server URL:")
+        self.server_input = QLineEdit("http://127.0.0.1:80")
+        self.refresh_progress_button = QPushButton("Refresh Progress")
+        self.refresh_progress_button.clicked.connect(self.refresh_progress)
+        self.refresh_best_button = QPushButton("Refresh Leaderboard")
+        self.refresh_best_button.clicked.connect(self.load_best)
+        server_layout.addWidget(server_label)
+        server_layout.addWidget(self.server_input)
+        server_layout.addWidget(self.refresh_progress_button)
+        server_layout.addWidget(self.refresh_best_button)
+        layout.addLayout(server_layout)
+
+        stats_layout = QHBoxLayout()
+        self.status_chip = QLabel("Idle")
+        self.status_chip.setObjectName("statusChip")
+        self.progress_label = QLabel("Progress: —")
+        self.backoff_label = QLabel("Min Backoff: —")
+        self.requests_label = QLabel("Requests Remaining: —")
+        self.avg_label = QLabel("Avg Task: —")
+        self.tasks_label = QLabel("24h Projection: —")
+        stats_layout.addWidget(self.status_chip)
+        stats_layout.addWidget(self.progress_label)
+        stats_layout.addWidget(self.backoff_label)
+        stats_layout.addWidget(self.requests_label)
+        stats_layout.addWidget(self.avg_label)
+        stats_layout.addWidget(self.tasks_label)
+        layout.addLayout(stats_layout)
+
+        controls_layout = QHBoxLayout()
+        self.add_token_button = QPushButton("Add Token")
+        self.add_token_button.clicked.connect(self.add_token_row)
+        self.start_all_button = QPushButton("Start All")
+        self.start_all_button.clicked.connect(self.start_all_tokens)
+        self.stop_all_button = QPushButton("Stop All")
+        self.stop_all_button.clicked.connect(self.stop_all_tokens)
+        controls_layout.addWidget(self.add_token_button)
+        controls_layout.addWidget(self.start_all_button)
+        controls_layout.addWidget(self.stop_all_button)
+        controls_layout.addStretch(1)
+        layout.addLayout(controls_layout)
+
+        self.table = TokenTable()
+        layout.addWidget(self.table)
+
+        tabs = QTabWidget()
+        self.log_view = QPlainTextEdit()
+        self.log_view.setReadOnly(True)
+        self.log_view.setMaximumBlockCount(2000)
+        tabs.addTab(self.log_view, "Logs")
+
+        self.best_table = QTableWidget(0, 5)
+        self.best_table.setHorizontalHeaderLabels([
+            "Hero",
+            "Hero ID",
+            "Player ID",
+            "Matches",
+            "Wins",
+        ])
+        self.best_table.verticalHeader().setVisible(False)
+        self.best_table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        self.best_table.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
+        for index in range(1, 5):
+            self.best_table.horizontalHeader().setSectionResizeMode(
+                index, QHeaderView.ResizeMode.ResizeToContents
+            )
+        tabs.addTab(self.best_table, "Leaderboard")
+
+        seed_widget = QWidget()
+        seed_layout = QVBoxLayout(seed_widget)
+        seed_box = QGroupBox("Seed Players")
+        seed_box_layout = QHBoxLayout()
+        seed_box.setLayout(seed_box_layout)
+        self.seed_start = QLineEdit()
+        self.seed_start.setPlaceholderText("Start ID")
+        self.seed_end = QLineEdit()
+        self.seed_end.setPlaceholderText("End ID")
+        self.seed_button = QPushButton("Seed Range")
+        self.seed_button.clicked.connect(self.seed_range)
+        seed_box_layout.addWidget(QLabel("Start:"))
+        seed_box_layout.addWidget(self.seed_start)
+        seed_box_layout.addWidget(QLabel("End:"))
+        seed_box_layout.addWidget(self.seed_end)
+        seed_box_layout.addWidget(self.seed_button)
+        seed_layout.addWidget(seed_box)
+        seed_layout.addStretch(1)
+        tabs.addTab(seed_widget, "Seed")
+
+        layout.addWidget(tabs)
+
+        self.setCentralWidget(central)
+
+    # ----- Token management -----
+    def add_token_row(self, value: str = "", max_requests: Optional[int] = None, persist: bool = True) -> None:
+        token_id = f"token-{self.token_counter}"
+        self.token_counter += 1
+        item = TokenItem(identifier=token_id, value=value.strip(), max_requests=max_requests)
+        row = self.table.rowCount()
+        self.table.insertRow(row)
+
+        token_edit = QLineEdit(item.value)
+        token_edit.textChanged.connect(partial(self._on_token_changed, item))
+
+        max_edit = QSpinBox()
+        max_edit.setRange(0, 1_000_000_000)
+        max_edit.setSpecialValueText("∞")
+        if max_requests is not None:
+            max_edit.setValue(max_requests)
+        else:
+            max_edit.setValue(0)
+        max_edit.valueChanged.connect(partial(self._on_max_changed, item))
+
+        status_label = QLabel("Idle")
+        backoff_label = QLabel("—")
+        requests_label = QLabel("—")
+        average_label = QLabel("—")
+        projection_label = QLabel("—")
+
+        start_button = QPushButton("Start")
+        start_button.clicked.connect(partial(self.start_token, item))
+        stop_button = QPushButton("Stop")
+        stop_button.clicked.connect(partial(self.stop_token, item))
+        stop_button.setEnabled(False)
+        remove_button = QPushButton("Remove")
+        remove_button.clicked.connect(partial(self.remove_token, item))
+
+        widgets = TokenWidgets(
+            token_edit=token_edit,
+            max_edit=max_edit,
+            status_label=status_label,
+            backoff_label=backoff_label,
+            requests_label=requests_label,
+            average_label=average_label,
+            projection_label=projection_label,
+            start_button=start_button,
+            stop_button=stop_button,
+            remove_button=remove_button,
+        )
+        item.widgets = widgets
+
+        self.table.setCellWidget(row, 0, token_edit)
+        self.table.setCellWidget(row, 1, max_edit)
+        self.table.setCellWidget(row, 2, status_label)
+        self.table.setCellWidget(row, 3, backoff_label)
+        self.table.setCellWidget(row, 4, requests_label)
+        self.table.setCellWidget(row, 5, average_label)
+        self.table.setCellWidget(row, 6, projection_label)
+        self.table.setCellWidget(row, 7, start_button)
+        self.table.setCellWidget(row, 8, stop_button)
+
+        self.tokens.append(item)
+        self._update_status_display(item)
+
+        if persist:
+            self._persist_tokens()
+        self._update_controls()
+        self._update_global_metrics()
+
+    def _on_token_changed(self, item: TokenItem, text: str) -> None:
+        item.value = text.strip()
+        self._persist_tokens()
+        self._update_controls()
+
+    def _on_max_changed(self, item: TokenItem, value: int) -> None:
+        item.max_requests = value if value > 0 else None
+        if item.status.requests_remaining is not None and not item.running:
+            item.status.requests_remaining = item.max_requests
+        self._persist_tokens()
+        self._update_status_display(item)
+        self._update_global_metrics()
+
+    def remove_token(self, item: TokenItem) -> None:
+        if item.running:
+            QMessageBox.warning(self, "Token running", "Stop the worker before removing the token.")
+            return
+        try:
+            row = self.tokens.index(item)
+        except ValueError:
+            return
+        self.tokens.pop(row)
+        self.table.removeRow(row)
+        self._persist_tokens()
+        self._update_controls()
+        self._update_global_metrics()
+        self._append_log(f"Removed token #{row + 1}.")
+
+    def start_token(self, item: TokenItem) -> None:
+        if item.running:
+            return
+        token_value = item.value.strip()
+        if not token_value:
+            QMessageBox.warning(self, "Token missing", "Enter a Stratz API token before starting.")
+            return
+        max_requests = item.max_requests
+        stop_event = Event()
+        config = WorkerConfig(
+            token_id=item.identifier,
+            token_value=token_value,
+            server_url=self.server_input.text(),
+            max_requests=max_requests,
+        )
+        process = Process(target=worker_entry, args=(config, stop_event, self.message_queue))
+        process.daemon = True
+        process.start()
+        item.worker = process
+        item.stop_event = stop_event
+        item.status.running = True
+        item.status.stop_requested = False
+        item.status.requests_remaining = max_requests
+        item.log_entries.clear()
+        self._append_log(f"Token {self._token_label(item)}: Worker started.")
+        self._update_status_display(item)
+        self._update_controls()
+        self._update_global_metrics()
+
+    def stop_token(self, item: TokenItem) -> None:
+        if not item.worker or not item.worker.is_alive():
+            return
+        if item.stop_event and not item.stop_event.is_set():
+            item.stop_event.set()
+        item.status.stop_requested = True
+        self._append_log(f"Token {self._token_label(item)}: Stop requested.")
+        self._update_status_display(item)
+        self._update_controls()
+        self._update_global_metrics()
+
+    def start_all_tokens(self) -> None:
+        for item in self.tokens:
+            if not item.running and item.value.strip():
+                self.start_token(item)
+
+    def stop_all_tokens(self) -> None:
+        for item in self.tokens:
+            self.stop_token(item)
+
+    def _cleanup_workers(self) -> None:
+        for item in self.tokens:
+            process = item.worker
+            if process and not process.is_alive():
+                process.join(timeout=0.1)
+                item.worker = None
+                item.stop_event = None
+                item.status.running = False
+                item.status.stop_requested = False
+                item.status.requests_remaining = item.max_requests
+                self._update_status_display(item)
+        self._update_controls()
+        self._update_global_metrics()
+
+    # ----- Persistence -----
+    def _persist_tokens(self) -> None:
+        try:
+            payload = [
+                {
+                    "token": token.value,
+                    "maxRequests": token.max_requests,
+                }
+                for token in self.tokens
+                if token.value
+            ]
+            with TOKENS_FILE.open("w", encoding="utf-8") as handle:
+                json.dump(payload, handle, indent=2)
+        except OSError:
+            pass
+
+    def _load_tokens(self) -> None:
+        if TOKENS_FILE.exists():
+            try:
+                data = json.loads(TOKENS_FILE.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                data = []
+            if isinstance(data, list):
+                for entry in data:
+                    if not isinstance(entry, dict):
+                        continue
+                    token_value = entry.get("token")
+                    max_requests = entry.get("maxRequests")
+                    try:
+                        max_int = int(max_requests) if max_requests is not None else None
+                    except (TypeError, ValueError):
+                        max_int = None
+                    if isinstance(token_value, str):
+                        self.add_token_row(token_value, max_int, persist=False)
+
+    def import_tokens(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(self, "Import Tokens", os.getcwd(), "JSON Files (*.json)")
+        if not path:
+            return
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                data = json.load(handle)
+        except (OSError, json.JSONDecodeError) as error:
+            QMessageBox.critical(self, "Import failed", f"Failed to load tokens: {error}")
+            return
+        imported = 0
+        for entry in data if isinstance(data, list) else []:
+            token_value = None
+            max_requests = None
+            if isinstance(entry, str):
+                token_value = entry
+            elif isinstance(entry, dict):
+                token_value = entry.get("token") or entry.get("value")
+                max_candidate = entry.get("maxRequests") or entry.get("max")
+                if max_candidate is not None:
+                    try:
+                        max_requests = int(max_candidate)
+                    except (TypeError, ValueError):
+                        max_requests = None
+            if isinstance(token_value, str) and token_value.strip():
+                self.add_token_row(token_value.strip(), max_requests, persist=False)
+                imported += 1
+        self._persist_tokens()
+        self._update_global_metrics()
+        QMessageBox.information(self, "Import complete", f"Imported {imported} token(s).")
+
+    def export_tokens(self) -> None:
+        path, _ = QFileDialog.getSaveFileName(self, "Export Tokens", os.getcwd(), "JSON Files (*.json)")
+        if not path:
+            return
+        payload = [
+            {
+                "token": token.value,
+                "maxRequests": token.max_requests,
+            }
+            for token in self.tokens
+            if token.value
+        ]
+        try:
+            with open(path, "w", encoding="utf-8") as handle:
+                json.dump(payload, handle, indent=2)
+        except OSError as error:
+            QMessageBox.critical(self, "Export failed", f"Unable to export tokens: {error}")
+            return
+        QMessageBox.information(self, "Export complete", f"Saved {len(payload)} token(s).")
+
+    # ----- Worker message handling -----
+    def process_worker_messages(self) -> None:
+        handled_any = False
+        while True:
+            try:
+                message = self.message_queue.get_nowait()
+            except queue.Empty:
+                break
+            handled_any = True
+            message_type = message.get("type")
+            if message_type == "log":
+                self._handle_log(message)
+            elif message_type == "status":
+                self._handle_status(message)
+            elif message_type == "refresh_progress":
+                self.refresh_progress()
+        if handled_any:
+            self._update_global_metrics()
+            self._update_controls()
+
+    def _handle_log(self, message: Dict[str, Any]) -> None:
+        token_id = message.get("token_id")
+        text = message.get("payload", {}).get("message")
+        if not isinstance(text, str):
+            return
+        token = self._find_token(token_id)
+        label = self._token_label(token) if token else token_id
+        line = f"[{label}] {text}"
+        if token:
+            token.log_entries.append(line)
+            if len(token.log_entries) > LOG_MAX_ENTRIES:
+                token.log_entries = token.log_entries[-LOG_MAX_ENTRIES:]
+        self._append_log(line)
+
+    def _handle_status(self, message: Dict[str, Any]) -> None:
+        token_id = message.get("token_id")
+        payload = message.get("payload", {})
+        token = self._find_token(token_id)
+        if not token:
+            return
+        status = token.status
+        status.running = bool(payload.get("running"))
+        status.backoff_ms = int(payload.get("backoff_ms", 0) or 0)
+        requests_remaining = payload.get("requests_remaining")
+        if requests_remaining in (None, "∞"):
+            status.requests_remaining = None
+        else:
+            try:
+                status.requests_remaining = int(requests_remaining)
+            except (TypeError, ValueError):
+                status.requests_remaining = None
+        status.completed_tasks = int(payload.get("completed_tasks", 0) or 0)
+        status.runtime_ms = float(payload.get("runtime_ms", 0) or 0)
+        avg_ms = payload.get("average_task_ms")
+        status.average_task_ms = float(avg_ms) if avg_ms is not None else None
+        tasks_day = payload.get("tasks_per_day")
+        status.tasks_per_day = float(tasks_day) if tasks_day is not None else None
+        status.stop_requested = bool(payload.get("stop_requested"))
+        status.timestamp_ms = payload.get("timestamp")
+        if not status.running:
+            token.worker = None
+            token.stop_event = None
+            status.stop_requested = False
+        self._update_status_display(token)
+
+    def _find_token(self, identifier: Optional[str]) -> Optional[TokenItem]:
+        for token in self.tokens:
+            if token.identifier == identifier:
+                return token
+        return None
+
+    # ----- Display helpers -----
+    def _token_label(self, token: Optional[TokenItem]) -> str:
+        if not token:
+            return "?"
+        try:
+            index = self.tokens.index(token)
+        except ValueError:
+            return token.identifier
+        return f"Token #{index + 1}"
+
+    def _append_log(self, text: str) -> None:
+        self.log_view.appendPlainText(text)
+        cursor = self.log_view.textCursor()
+        cursor.movePosition(QTextCursor.MoveOperation.End)
+        self.log_view.setTextCursor(cursor)
+
+    def _update_status_display(self, token: TokenItem) -> None:
+        if not token.widgets:
+            return
+        status = token.status
+        widgets = token.widgets
+
+        running = status.running
+        if status.stop_requested and running:
+            widgets.status_label.setText("Stopping…")
+        elif running:
+            widgets.status_label.setText("Running")
+        else:
+            widgets.status_label.setText("Idle")
+
+        widgets.backoff_label.setText(self._format_duration(status.backoff_ms))
+        if status.requests_remaining is None:
+            widgets.requests_label.setText("∞")
+        else:
+            widgets.requests_label.setText(str(status.requests_remaining))
+        widgets.average_label.setText(self._format_average(status.average_task_ms))
+        widgets.projection_label.setText(self._format_tasks(status.tasks_per_day))
+
+        widgets.start_button.setEnabled(not running and not status.stop_requested)
+        widgets.stop_button.setEnabled(running and not status.stop_requested)
+        widgets.remove_button.setEnabled(not running)
+        widgets.token_edit.setEnabled(not running)
+        widgets.max_edit.setEnabled(not running)
+
+    def _format_duration(self, ms: Optional[float]) -> str:
+        if ms is None or ms <= 0:
+            return "—"
+        if ms < 1000:
+            return f"{int(ms)} ms"
+        if ms < 60_000:
+            return f"{ms / 1000:.1f} s"
+        minutes = round(ms / 60_000)
+        return f"{minutes} min"
+
+    def _format_average(self, ms: Optional[float]) -> str:
+        if ms is None or ms <= 0:
+            return "—"
+        return self._format_duration(ms)
+
+    def _format_tasks(self, tasks: Optional[float]) -> str:
+        if tasks is None or tasks <= 0:
+            return "—"
+        if tasks >= 100:
+            return f"{tasks:.0f}"
+        return f"{tasks:.1f}"
+
+    def _update_controls(self) -> None:
+        any_running = any(token.status.running for token in self.tokens)
+        self.start_all_button.setEnabled(any(token.value.strip() and not token.status.running for token in self.tokens))
+        self.stop_all_button.setEnabled(any_running)
+        if any_running:
+            self.status_chip.setText("Running")
+        else:
+            self.status_chip.setText("Idle")
+
+    def _update_global_metrics(self) -> None:
+        running_tokens = [token for token in self.tokens if token.status.running]
+        if running_tokens:
+            min_backoff = min(token.status.backoff_ms for token in running_tokens)
+            self.backoff_label.setText(f"Min Backoff: {self._format_duration(min_backoff)}")
+        else:
+            self.backoff_label.setText("Min Backoff: —")
+
+        request_sum = 0
+        unknown = False
+        for token in running_tokens:
+            if token.status.requests_remaining is None:
+                unknown = True
+                break
+            request_sum += token.status.requests_remaining
+        if not running_tokens:
+            self.requests_label.setText("Requests Remaining: —")
+        elif unknown:
+            self.requests_label.setText("Requests Remaining: ∞")
+        else:
+            self.requests_label.setText(f"Requests Remaining: {request_sum}")
+
+        total_runtime = 0.0
+        total_tasks = 0
+        total_projection = 0.0
+        projection_count = 0
+        for token in self.tokens:
+            status = token.status
+            total_runtime += status.runtime_ms
+            total_tasks += status.completed_tasks
+            if status.tasks_per_day and status.tasks_per_day > 0:
+                total_projection += status.tasks_per_day
+                projection_count += 1
+        if total_tasks > 0 and total_runtime > 0:
+            average_ms = total_runtime / total_tasks
+            self.avg_label.setText(f"Avg Task: {self._format_duration(average_ms)}")
+        else:
+            self.avg_label.setText("Avg Task: —")
+        if projection_count:
+            self.tasks_label.setText(f"24h Projection: {self._format_tasks(total_projection)}")
+        else:
+            self.tasks_label.setText("24h Projection: —")
+
+    # ----- Networking helpers -----
+    def _server_url(self) -> str:
+        value = self.server_input.text().strip()
+        if not value:
+            return "http://127.0.0.1:80"
+        return value.rstrip("/")
+
+    def refresh_progress(self) -> None:
+        import requests
+
+        try:
+            response = requests.get(f"{self._server_url()}/progress", timeout=15)
+            response.raise_for_status()
+            payload = response.json()
+        except requests.RequestException as error:
+            self.progress_label.setText(f"Progress: error ({error})")
+            return
+        hero_done = payload.get("hero_done")
+        discover_done = payload.get("discover_done")
+        total_players = payload.get("players_total")
+        if all(isinstance(value, int) for value in (hero_done, discover_done, total_players)):
+            hero_text = f"Hero: {hero_done} / {total_players}"
+            discover_text = f"Discover: {discover_done} / {total_players}"
+            self.progress_label.setText(f"Progress: {hero_text} • {discover_text}")
+        else:
+            self.progress_label.setText("Progress: unavailable")
+
+    def load_best(self) -> None:
+        import requests
+
+        try:
+            response = requests.get(f"{self._server_url()}/best", timeout=15)
+            response.raise_for_status()
+            rows = response.json()
+        except requests.RequestException as error:
+            QMessageBox.warning(self, "Leaderboard", f"Failed to load leaderboard: {error}")
+            return
+        if not isinstance(rows, list):
+            rows = []
+        self.best_table.setRowCount(0)
+        for row_data in rows:
+            row = self.best_table.rowCount()
+            self.best_table.insertRow(row)
+            hero_name = row_data.get("hero_name") or "—"
+            hero_id = row_data.get("hero_id") or "—"
+            player_id = row_data.get("player_id") or "—"
+            matches = row_data.get("matches") or "—"
+            wins = row_data.get("wins") or "—"
+            for column, value in enumerate([hero_name, hero_id, player_id, matches, wins]):
+                item = QTableWidgetItem(str(value))
+                self.best_table.setItem(row, column, item)
+
+    def seed_range(self) -> None:
+        import requests
+
+        try:
+            start = int(self.seed_start.text())
+            end = int(self.seed_end.text())
+        except ValueError:
+            QMessageBox.warning(self, "Seed", "Enter numeric start and end IDs.")
+            return
+        if end < start:
+            QMessageBox.warning(self, "Seed", "End ID must be greater than start ID.")
+            return
+        try:
+            response = requests.get(
+                f"{self._server_url()}/seed",
+                params={"start": start, "end": end},
+                timeout=30,
+            )
+            response.raise_for_status()
+            payload = response.json()
+        except requests.RequestException as error:
+            QMessageBox.warning(self, "Seed", f"Failed to seed range: {error}")
+            return
+        seeded = payload.get("seeded")
+        if isinstance(seeded, list) and len(seeded) == 2:
+            self._append_log(f"Seeded IDs {seeded[0]} - {seeded[1]}.")
+        else:
+            self._append_log("Seed request completed.")
+
+    # ----- Qt overrides -----
+    def closeEvent(self, event) -> None:  # type: ignore[override]
+        self.stop_all_tokens()
+        for item in self.tokens:
+            if item.worker and item.worker.is_alive():
+                item.worker.join(timeout=1)
+        return super().closeEvent(event)
+
+
+def main() -> int:
+    freeze_support()
+    app = QApplication(sys.argv)
+    window = ClientWindow()
+    window.show()
+    return app.exec()

--- a/stratz_scraper/client/application.py
+++ b/stratz_scraper/client/application.py
@@ -185,12 +185,18 @@ class ClientWindow(QMainWindow):
 
         controls_layout = QHBoxLayout()
         self.add_token_button = QPushButton("Add Token")
-        self.add_token_button.clicked.connect(self.add_token_row)
+        self.add_token_button.clicked.connect(lambda: self.add_token_row())
+        self.import_tokens_button = QPushButton("Import Tokens…")
+        self.import_tokens_button.clicked.connect(lambda: self.import_tokens())
+        self.export_tokens_button = QPushButton("Export Tokens…")
+        self.export_tokens_button.clicked.connect(lambda: self.export_tokens())
         self.start_all_button = QPushButton("Start All")
-        self.start_all_button.clicked.connect(self.start_all_tokens)
+        self.start_all_button.clicked.connect(lambda: self.start_all_tokens())
         self.stop_all_button = QPushButton("Stop All")
-        self.stop_all_button.clicked.connect(self.stop_all_tokens)
+        self.stop_all_button.clicked.connect(lambda: self.stop_all_tokens())
         controls_layout.addWidget(self.add_token_button)
+        controls_layout.addWidget(self.import_tokens_button)
+        controls_layout.addWidget(self.export_tokens_button)
         controls_layout.addWidget(self.start_all_button)
         controls_layout.addWidget(self.stop_all_button)
         controls_layout.addStretch(1)
@@ -247,10 +253,16 @@ class ClientWindow(QMainWindow):
         self.setCentralWidget(central)
 
     # ----- Token management -----
-    def add_token_row(self, value: str = "", max_requests: Optional[int] = None, persist: bool = True) -> None:
+    def add_token_row(
+        self,
+        value: str = "",
+        max_requests: Optional[int] = None,
+        persist: bool = True,
+    ) -> None:
         token_id = f"token-{self.token_counter}"
         self.token_counter += 1
-        item = TokenItem(identifier=token_id, value=value.strip(), max_requests=max_requests)
+        token_value = value.strip() if isinstance(value, str) else ""
+        item = TokenItem(identifier=token_id, value=token_value, max_requests=max_requests)
         row = self.table.rowCount()
         self.table.insertRow(row)
 
@@ -325,7 +337,7 @@ class ClientWindow(QMainWindow):
         self._update_status_display(item)
         self._update_global_metrics()
 
-    def remove_token(self, item: TokenItem) -> None:
+    def remove_token(self, item: TokenItem, *_: object) -> None:
         if item.running:
             QMessageBox.warning(self, "Token running", "Stop the worker before removing the token.")
             return
@@ -340,7 +352,7 @@ class ClientWindow(QMainWindow):
         self._update_global_metrics()
         self._append_log(f"Removed token #{row + 1}.")
 
-    def start_token(self, item: TokenItem) -> None:
+    def start_token(self, item: TokenItem, *_: object) -> None:
         if item.running:
             return
         token_value = item.value.strip()
@@ -369,7 +381,7 @@ class ClientWindow(QMainWindow):
         self._update_controls()
         self._update_global_metrics()
 
-    def stop_token(self, item: TokenItem) -> None:
+    def stop_token(self, item: TokenItem, *_: object) -> None:
         if not item.worker or not item.worker.is_alive():
             return
         if item.stop_event and not item.stop_event.is_set():
@@ -380,12 +392,12 @@ class ClientWindow(QMainWindow):
         self._update_controls()
         self._update_global_metrics()
 
-    def start_all_tokens(self) -> None:
+    def start_all_tokens(self, *_: object) -> None:
         for item in self.tokens:
             if not item.running and item.value.strip():
                 self.start_token(item)
 
-    def stop_all_tokens(self) -> None:
+    def stop_all_tokens(self, *_: object) -> None:
         for item in self.tokens:
             self.stop_token(item)
 
@@ -438,7 +450,7 @@ class ClientWindow(QMainWindow):
                     if isinstance(token_value, str):
                         self.add_token_row(token_value, max_int, persist=False)
 
-    def import_tokens(self) -> None:
+    def import_tokens(self, *_: object) -> None:
         path, _ = QFileDialog.getOpenFileName(self, "Import Tokens", os.getcwd(), "JSON Files (*.json)")
         if not path:
             return
@@ -469,7 +481,7 @@ class ClientWindow(QMainWindow):
         self._update_global_metrics()
         QMessageBox.information(self, "Import complete", f"Imported {imported} token(s).")
 
-    def export_tokens(self) -> None:
+    def export_tokens(self, *_: object) -> None:
         path, _ = QFileDialog.getSaveFileName(self, "Export Tokens", os.getcwd(), "JSON Files (*.json)")
         if not path:
             return
@@ -685,7 +697,7 @@ class ClientWindow(QMainWindow):
             return "http://127.0.0.1:80"
         return value.rstrip("/")
 
-    def refresh_progress(self) -> None:
+    def refresh_progress(self, *_: object) -> None:
         import requests
 
         try:
@@ -705,7 +717,7 @@ class ClientWindow(QMainWindow):
         else:
             self.progress_label.setText("Progress: unavailable")
 
-    def load_best(self) -> None:
+    def load_best(self, *_: object) -> None:
         import requests
 
         try:
@@ -730,7 +742,7 @@ class ClientWindow(QMainWindow):
                 item = QTableWidgetItem(str(value))
                 self.best_table.setItem(row, column, item)
 
-    def seed_range(self) -> None:
+    def seed_range(self, *_: object) -> None:
         import requests
 
         try:

--- a/stratz_scraper/client/worker.py
+++ b/stratz_scraper/client/worker.py
@@ -1,0 +1,548 @@
+"""Background worker processes for the PyQt client."""
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass
+from email.utils import parsedate_to_datetime
+from multiprocessing import Event, Queue
+from typing import Any, Dict, List, Optional
+
+import requests
+
+DAY_IN_MS = 86_400_000
+INITIAL_BACKOFF_MS = 1_000
+MAX_BACKOFF_MS = DAY_IN_MS
+NO_TASK_WAIT_MS = 60_000
+NO_TASK_RETRY_DELAY_MS = 100
+TASK_RESET_TIMEOUT = 10
+
+
+class RateLimitError(RuntimeError):
+    """Raised when the Stratz API responds with a retry hint."""
+
+    def __init__(self, message: str, retry_after_ms: Optional[int] = None) -> None:
+        super().__init__(message)
+        self.retry_after_ms = retry_after_ms
+
+
+@dataclass
+class WorkerConfig:
+    token_id: str
+    token_value: str
+    server_url: str
+    max_requests: Optional[int] = None
+    client_name: str = "pyqt"
+
+
+@dataclass
+class WorkerState:
+    requests_remaining: Optional[int]
+    completed_tasks: int
+    runtime_ms: float
+    backoff_ms: int
+
+
+@dataclass
+class WorkerMessage:
+    type: str
+    token_id: str
+    payload: Dict[str, Any]
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _monotonic_ms() -> float:
+    return time.monotonic() * 1000.0
+
+
+def _format_server_url(url: str) -> str:
+    url = url.strip()
+    if not url:
+        return "http://127.0.0.1:80"
+    if url.endswith("/"):
+        url = url[:-1]
+    return url
+
+
+def _parse_retry_after(value: Optional[str]) -> Optional[int]:
+    if not value:
+        return None
+    value = value.strip()
+    if not value:
+        return None
+    try:
+        seconds = float(value)
+    except ValueError:
+        try:
+            parsed = parsedate_to_datetime(value)
+        except (TypeError, ValueError):
+            return None
+        if parsed is None:
+            return None
+        delta = parsed.timestamp() - time.time()
+        if delta <= 0:
+            return None
+        return int(math.ceil(delta * 1000))
+    else:
+        if not math.isfinite(seconds) or seconds < 0:
+            return None
+        return int(math.ceil(seconds * 1000))
+
+
+def _wait(stop_event: Event, duration_ms: int) -> None:
+    if duration_ms <= 0:
+        return
+    deadline = time.monotonic() + duration_ms / 1000
+    while not stop_event.is_set():
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        time.sleep(min(0.5, remaining))
+
+
+def _server_post(session: requests.Session, url: str, path: str, json_payload: dict, timeout: int = 30) -> dict:
+    response = session.post(f"{url}{path}", json=json_payload, timeout=timeout)
+    response.raise_for_status()
+    if not response.content:
+        return {}
+    try:
+        return response.json()
+    except ValueError:
+        return {}
+
+
+def _fetch_task(session: requests.Session, url: str, client_name: str) -> Optional[dict]:
+    payload = _server_post(session, url, "/task", {"client": client_name})
+    task = payload.get("task")
+    if task is None:
+        return None
+    if isinstance(task, dict):
+        return task
+    return None
+
+
+def _reset_task(session: requests.Session, url: str, task: dict) -> None:
+    if not task:
+        return
+    json_payload = {
+        "steamAccountId": task.get("steamAccountId"),
+        "type": task.get("type"),
+    }
+    try:
+        _server_post(session, url, "/task/reset", json_payload, timeout=TASK_RESET_TIMEOUT)
+    except requests.RequestException:
+        pass
+
+
+def _submit_hero_stats(session: requests.Session, url: str, player_id: int, heroes: list) -> Optional[dict]:
+    payload = _server_post(
+        session,
+        url,
+        "/submit",
+        {
+            "type": "fetch_hero_stats",
+            "steamAccountId": player_id,
+            "heroes": heroes,
+            "task": True,
+        },
+    )
+    return payload.get("task") if isinstance(payload, dict) else None
+
+
+def _submit_discovery(
+    session: requests.Session,
+    url: str,
+    player_id: int,
+    discovered: List[dict],
+    depth: Optional[int],
+) -> Optional[dict]:
+    payload = _server_post(
+        session,
+        url,
+        "/submit",
+        {
+            "type": "discover_matches",
+            "steamAccountId": player_id,
+            "discovered": discovered,
+            "depth": depth,
+            "task": True,
+        },
+    )
+    return payload.get("task") if isinstance(payload, dict) else None
+
+
+def _execute_stratz_query(session: requests.Session, token: str, query: str, variables: dict) -> dict:
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    response = session.post(
+        "https://api.stratz.com/graphql",
+        headers=headers,
+        json={"query": query, "variables": variables},
+        timeout=60,
+    )
+    if response.status_code == 429:
+        retry_after = _parse_retry_after(response.headers.get("retry-after"))
+        raise RateLimitError("Stratz API rate limit", retry_after_ms=retry_after)
+    response.raise_for_status()
+    payload = response.json()
+    if payload and isinstance(payload, dict) and payload.get("errors"):
+        first_error = payload["errors"][0]
+        message = first_error.get("message") if isinstance(first_error, dict) else None
+        raise RuntimeError(message or "Stratz API returned errors")
+    return payload
+
+
+def _fetch_player_heroes(session: requests.Session, token: str, player_id: int) -> List[dict]:
+    query = """
+        query HeroPerf($id: Long!) {
+          player(steamAccountId: $id) {
+            heroesPerformance(request: { take: 999999, gameModeIds: [1, 22] }, take: 200) {
+              heroId
+              matchCount
+              winCount
+            }
+          }
+        }
+    """
+    payload = _execute_stratz_query(session, token, query, {"id": player_id})
+    heroes = (
+        payload.get("data", {})
+        .get("player", {})
+        .get("heroesPerformance", [])
+    )
+    results: List[dict] = []
+    if isinstance(heroes, list):
+        for entry in heroes:
+            if not isinstance(entry, dict):
+                continue
+            hero_id = entry.get("heroId")
+            match_count = entry.get("matchCount")
+            win_count = entry.get("winCount")
+            try:
+                hero_id = int(hero_id)
+                match_count = int(match_count)
+                win_count = int(win_count)
+            except (TypeError, ValueError):
+                continue
+            results.append(
+                {
+                    "heroId": hero_id,
+                    "matches": match_count,
+                    "wins": win_count,
+                }
+            )
+    return results
+
+
+def _discover_matches(
+    session: requests.Session,
+    token: str,
+    player_id: int,
+    take: int = 100,
+) -> List[dict]:
+    query = """
+        query PlayerMatches($steamAccountId: Long!, $take: Int!, $skip: Int!) {
+          player(steamAccountId: $steamAccountId) {
+            matches(request: { take: $take, skip: $skip }) {
+              id
+              players {
+                steamAccountId
+              }
+            }
+          }
+        }
+    """
+    discovered: dict[int, int] = {}
+    order: List[int] = []
+    skip = 0
+    take = max(1, int(take))
+    while True:
+        payload = _execute_stratz_query(
+            session,
+            token,
+            query,
+            {"steamAccountId": player_id, "take": take, "skip": skip},
+        )
+        matches = (
+            payload.get("data", {})
+            .get("player", {})
+            .get("matches", [])
+        )
+        if not isinstance(matches, list) or not matches:
+            break
+        for match in matches:
+            players = match.get("players") if isinstance(match, dict) else None
+            if not isinstance(players, list):
+                continue
+            for participant in players:
+                if not isinstance(participant, dict):
+                    continue
+                candidate = participant.get("steamAccountId")
+                try:
+                    candidate = int(candidate)
+                except (TypeError, ValueError):
+                    continue
+                if candidate <= 0 or candidate == player_id:
+                    continue
+                if candidate not in discovered:
+                    discovered[candidate] = 1
+                    order.append(candidate)
+                else:
+                    discovered[candidate] += 1
+        if len(matches) < take:
+            break
+        skip += len(matches)
+    return [
+        {"steamAccountId": account_id, "count": discovered[account_id]}
+        for account_id in order
+    ]
+
+
+def _send(queue: Queue, message: WorkerMessage) -> None:
+    queue.put({
+        "type": message.type,
+        "token_id": message.token_id,
+        "payload": message.payload,
+    })
+
+
+def _send_log(queue: Queue, token_id: str, text: str) -> None:
+    _send(queue, WorkerMessage("log", token_id, {"message": text, "timestamp": _now_ms()}))
+
+
+def _send_status(
+    queue: Queue,
+    token_id: str,
+    running: bool,
+    state: WorkerState,
+    stop_requested: bool,
+) -> None:
+    average_ms = None
+    tasks_per_day = None
+    if state.completed_tasks > 0 and state.runtime_ms > 0:
+        average_ms = state.runtime_ms / state.completed_tasks
+        if average_ms > 0:
+            tasks_per_day = DAY_IN_MS / average_ms
+    payload = {
+        "running": running,
+        "backoff_ms": state.backoff_ms,
+        "requests_remaining": state.requests_remaining,
+        "completed_tasks": state.completed_tasks,
+        "runtime_ms": state.runtime_ms,
+        "average_task_ms": average_ms,
+        "tasks_per_day": tasks_per_day,
+        "stop_requested": stop_requested,
+        "timestamp": _now_ms(),
+    }
+    _send(queue, WorkerMessage("status", token_id, payload))
+
+
+def _send_refresh_progress(queue: Queue) -> None:
+    queue.put({"type": "refresh_progress"})
+
+
+def worker_entry(config: WorkerConfig, stop_event: Event, queue: Queue) -> None:
+    server_url = _format_server_url(config.server_url)
+    token_value = config.token_value.strip()
+    session = requests.Session()
+    stratz_session = requests.Session()
+    requests_remaining = config.max_requests
+    completed_tasks = 0
+    start_ms = _monotonic_ms()
+    backoff_ms = INITIAL_BACKOFF_MS
+    state = WorkerState(requests_remaining=requests_remaining, completed_tasks=completed_tasks, runtime_ms=0, backoff_ms=backoff_ms)
+    _send_log(queue, config.token_id, "Worker started.")
+    if requests_remaining is not None:
+        _send_log(queue, config.token_id, f"Request limit {requests_remaining}.")
+    _send_status(queue, config.token_id, True, state, stop_requested=False)
+
+    task: Optional[dict] = None
+
+    try:
+        while not stop_event.is_set():
+            current_runtime_ms = _monotonic_ms() - start_ms
+            state.runtime_ms = current_runtime_ms
+            state.backoff_ms = backoff_ms
+            state.requests_remaining = requests_remaining
+            state.completed_tasks = completed_tasks
+            _send_status(
+                queue,
+                config.token_id,
+                True,
+                state,
+                stop_requested=stop_event.is_set(),
+            )
+
+            try:
+                if task is None:
+                    task = _fetch_task(session, server_url, config.client_name)
+                    if stop_event.is_set():
+                        break
+                    if task is None:
+                        backoff_ms = NO_TASK_WAIT_MS
+                        state.runtime_ms = _monotonic_ms() - start_ms
+                        state.backoff_ms = backoff_ms
+                        _send_status(
+                            queue,
+                            config.token_id,
+                            True,
+                            state,
+                            stop_requested=stop_event.is_set(),
+                        )
+                        _send_log(
+                            queue,
+                            config.token_id,
+                            "No tasks available. Waiting 60 seconds before retrying.",
+                        )
+                        _wait(stop_event, NO_TASK_WAIT_MS)
+                        continue
+
+                if stop_event.is_set():
+                    if task is not None:
+                        _reset_task(session, server_url, task)
+                        task = None
+                    break
+
+                task_id = task.get("steamAccountId")
+                task_type = task.get("type")
+                next_task: Optional[dict] = None
+
+                if task_type == "fetch_hero_stats":
+                    try:
+                        player_id = int(task_id)
+                    except (TypeError, ValueError):
+                        _send_log(queue, config.token_id, f"Invalid task id {task_id}. Resetting task.")
+                        _reset_task(session, server_url, task)
+                        task = None
+                        backoff_ms = INITIAL_BACKOFF_MS
+                        continue
+                    _send_log(queue, config.token_id, f"Hero stats task for {player_id}.")
+                    heroes = _fetch_player_heroes(stratz_session, token_value, player_id)
+                    _send_log(queue, config.token_id, f"Fetched {len(heroes)} heroes for {task_id}.")
+                    next_task = _submit_hero_stats(session, server_url, player_id, heroes)
+                    _send_log(queue, config.token_id, f"Submitted {len(heroes)} heroes for {task_id}.")
+                elif task_type == "discover_matches":
+                    depth = task.get("depth")
+                    try:
+                        player_id = int(task_id)
+                    except (TypeError, ValueError):
+                        _send_log(queue, config.token_id, f"Invalid task id {task_id}. Resetting task.")
+                        _reset_task(session, server_url, task)
+                        task = None
+                        backoff_ms = INITIAL_BACKOFF_MS
+                        continue
+                    _send_log(
+                        queue,
+                        config.token_id,
+                        f"Discovery task for {player_id} (depth {depth if depth is not None else 0}).",
+                    )
+                    discovered = _discover_matches(stratz_session, token_value, player_id)
+                    _send_log(queue, config.token_id, f"Discovered {len(discovered)} accounts from {task_id}.")
+                    next_task = _submit_discovery(session, server_url, player_id, discovered, depth)
+                    _send_log(queue, config.token_id, f"Submitted discovery results for {task_id}.")
+                else:
+                    _send_log(queue, config.token_id, f"Unknown task type {task_type}. Resetting {task_id}.")
+                    _reset_task(session, server_url, task)
+                    task = None
+                    backoff_ms = INITIAL_BACKOFF_MS
+                    continue
+
+                completed_tasks += 1
+                state.completed_tasks = completed_tasks
+                state.runtime_ms = _monotonic_ms() - start_ms
+                state.backoff_ms = backoff_ms
+                _send_status(
+                    queue,
+                    config.token_id,
+                    True,
+                    state,
+                    stop_requested=stop_event.is_set(),
+                )
+                _send_refresh_progress(queue)
+
+                if requests_remaining is not None:
+                    requests_remaining = max(0, requests_remaining - 1)
+                    state.requests_remaining = requests_remaining
+                    if requests_remaining == 0:
+                        if next_task is not None:
+                            _reset_task(session, server_url, next_task)
+                        _send_log(queue, config.token_id, "Reached request limit. Stopping worker.")
+                        break
+
+                task = next_task
+                backoff_ms = 10_000
+                if task is None:
+                    _wait(stop_event, NO_TASK_RETRY_DELAY_MS)
+            except RateLimitError as rate_error:
+                retry_after_ms = rate_error.retry_after_ms
+                wait_ms = retry_after_ms if retry_after_ms is not None else backoff_ms
+                wait_ms = max(0, min(int(wait_ms), MAX_BACKOFF_MS))
+                backoff_ms = wait_ms
+                state.runtime_ms = _monotonic_ms() - start_ms
+                state.backoff_ms = wait_ms
+                _send_status(
+                    queue,
+                    config.token_id,
+                    True,
+                    state,
+                    stop_requested=stop_event.is_set(),
+                )
+                _send_log(queue, config.token_id, f"Rate limited. Waiting {wait_ms / 1000:.1f}s.")
+                _wait(stop_event, wait_ms)
+                if retry_after_ms is None:
+                    backoff_ms = min(int(math.ceil(max(backoff_ms, 1000) * 1.2)), MAX_BACKOFF_MS)
+                task = None
+            except requests.RequestException as request_error:
+                message = str(request_error)
+                _send_log(queue, config.token_id, f"Network error: {message}")
+                if task is not None:
+                    _reset_task(session, server_url, task)
+                    task = None
+                wait_ms = min(max(backoff_ms, 1_000), MAX_BACKOFF_MS)
+                state.runtime_ms = _monotonic_ms() - start_ms
+                state.backoff_ms = wait_ms
+                _send_status(
+                    queue,
+                    config.token_id,
+                    True,
+                    state,
+                    stop_requested=stop_event.is_set(),
+                )
+                _wait(stop_event, wait_ms)
+                backoff_ms = min(int(math.ceil(max(backoff_ms, 1_000) * 1.2)), MAX_BACKOFF_MS)
+            except Exception as exc:  # noqa: BLE001
+                message = str(exc)
+                _send_log(queue, config.token_id, f"Error: {message}")
+                if task is not None:
+                    _reset_task(session, server_url, task)
+                    task = None
+                wait_ms = min(max(backoff_ms, 5_000), MAX_BACKOFF_MS)
+                state.runtime_ms = _monotonic_ms() - start_ms
+                state.backoff_ms = wait_ms
+                _send_status(
+                    queue,
+                    config.token_id,
+                    True,
+                    state,
+                    stop_requested=stop_event.is_set(),
+                )
+                _wait(stop_event, wait_ms)
+                backoff_ms = min(int(math.ceil(max(backoff_ms, 5_000) * 1.2)), MAX_BACKOFF_MS)
+    finally:
+        state.runtime_ms = _monotonic_ms() - start_ms
+        state.backoff_ms = INITIAL_BACKOFF_MS
+        state.requests_remaining = requests_remaining
+        state.completed_tasks = completed_tasks
+        _send_status(
+            queue,
+            config.token_id,
+            False,
+            state,
+            stop_requested=stop_event.is_set(),
+        )
+        _send_log(queue, config.token_id, "Worker stopped.")

--- a/stratz_scraper/client/worker.py
+++ b/stratz_scraper/client/worker.py
@@ -189,11 +189,12 @@ def _submit_discovery(
 
 def _execute_stratz_query(session: requests.Session, token: str, query: str, variables: dict) -> dict:
     headers = {
+        **DEFAULT_STRATZ_HEADERS,
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
         "Accept": session.headers.get("Accept", "*/*"),
         "apollographql-client-name": "web",
-        "apollographql-client-version": "1.0",
+        "apollographql-client-version": "1.0"
     }
     response = session.post(
         "https://api.stratz.com/graphql",

--- a/stratz_scraper/client/worker.py
+++ b/stratz_scraper/client/worker.py
@@ -178,7 +178,9 @@ def _execute_stratz_query(session: requests.Session, token: str, query: str, var
     headers = {
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
-        "Accept": "application/json",
+        "Accept": "application/json, text/plain, */*",
+        "apollographql-client-name": "web",
+        "apollographql-client-version": "1.0",
     }
     response = session.post(
         "https://api.stratz.com/graphql",
@@ -362,11 +364,16 @@ def worker_entry(config: WorkerConfig, stop_event: Event, queue: Queue) -> None:
             "User-Agent": (
                 "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
                 "AppleWebKit/537.36 (KHTML, like Gecko) "
-                "StratzScraper/1.0"
+                "Chrome/126.0.0.0 Safari/537.36"
             ),
-            "Accept": "application/json",
+            "Accept": "application/json, text/plain, */*",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Accept-Encoding": "gzip, deflate, br, zstd",
             "Origin": "https://stratz.com",
             "Referer": "https://stratz.com/",
+            "Sec-Ch-Ua": '"Not/A)Brand";v="8", "Chromium";v="126", "Google Chrome";v="126"',
+            "Sec-Ch-Ua-Mobile": "?0",
+            "Sec-Ch-Ua-Platform": '"Windows"',
         }
     )
     requests_remaining = config.max_requests

--- a/stratz_scraper/client/worker.py
+++ b/stratz_scraper/client/worker.py
@@ -18,14 +18,8 @@ NO_TASK_RETRY_DELAY_MS = 100
 TASK_RESET_TIMEOUT = 10
 DEFAULT_STRATZ_HEADERS = {
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:143.0) Gecko/20100101 Firefox/143.0",
-    "Accept": "*/*",
-    "Accept-Language": "en-GB,en;q=0.5",
-    "Accept-Encoding": "gzip, deflate, br, zstd",
-    "Connection": "keep-alive",
-    "Sec-Fetch-Dest": "empty",
-    "Sec-Fetch-Mode": "cors",
-    "Sec-Fetch-Site": "cross-site",
-    "Priority": "u=4",
+    "Accept": "application/json",
+    "Content-Type": "application/json",
 }
 
 
@@ -189,9 +183,6 @@ def _execute_stratz_query(session: requests.Session, token: str, query: str, var
     headers = {
         **DEFAULT_STRATZ_HEADERS,
         "Authorization": f"Bearer {token}",
-        "Content-Type": "application/json",
-        "apollographql-client-name": "web",
-        "apollographql-client-version": "1.0"
     }
     print("POST headers:", headers)
     print("POST body:", {"query": query, "variables": variables})

--- a/stratz_scraper/client/worker.py
+++ b/stratz_scraper/client/worker.py
@@ -1,14 +1,30 @@
 """Background worker processes for the PyQt client."""
 from __future__ import annotations
 
+import json
 import math
 import time
 from dataclasses import dataclass
 from email.utils import parsedate_to_datetime
 from multiprocessing import Event, Queue
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import requests
+
+try:
+    from selenium import webdriver
+    from selenium.common.exceptions import WebDriverException
+    from selenium.webdriver.chrome.options import Options as ChromeOptions
+    from selenium.webdriver.common.by import By
+    from selenium.webdriver.edge.options import Options as EdgeOptions
+    from selenium.webdriver.firefox.options import Options as FirefoxOptions
+except Exception:  # pragma: no cover - selenium is optional at runtime
+    webdriver = None
+    WebDriverException = Exception
+    ChromeOptions = None
+    EdgeOptions = None
+    FirefoxOptions = None
+    By = None
 
 DAY_IN_MS = 86_400_000
 INITIAL_BACKOFF_MS = 1_000
@@ -16,6 +32,39 @@ MAX_BACKOFF_MS = DAY_IN_MS
 NO_TASK_WAIT_MS = 60_000
 NO_TASK_RETRY_DELAY_MS = 100
 TASK_RESET_TIMEOUT = 10
+HTTPBIN_HEADERS_URL = "https://httpbin.org/headers"
+
+DEFAULT_STRATZ_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/126.0.0.0 Safari/537.36"
+    ),
+    "Accept": "application/json, text/plain, */*",
+    "Accept-Language": "en-US,en;q=0.9",
+    "Accept-Encoding": "gzip, deflate, br, zstd",
+    "Origin": "https://stratz.com",
+    "Referer": "https://stratz.com/",
+    "Sec-Ch-Ua": '"Not/A)Brand";v="8", "Chromium";v="126", "Google Chrome";v="126"',
+    "Sec-Ch-Ua-Mobile": "?0",
+    "Sec-Ch-Ua-Platform": '"Windows"',
+    "Sec-Fetch-Dest": "empty",
+    "Sec-Fetch-Mode": "cors",
+    "Sec-Fetch-Site": "same-site",
+}
+
+BROWSER_HEADER_KEYS = {
+    "Accept",
+    "Accept-Encoding",
+    "Accept-Language",
+    "User-Agent",
+    "Sec-Ch-Ua",
+    "Sec-Ch-Ua-Mobile",
+    "Sec-Ch-Ua-Platform",
+    "Sec-Fetch-Dest",
+    "Sec-Fetch-Mode",
+    "Sec-Fetch-Site",
+}
 
 
 class RateLimitError(RuntimeError):
@@ -103,6 +152,120 @@ def _wait(stop_event: Event, duration_ms: int) -> None:
         time.sleep(min(0.5, remaining))
 
 
+def _create_chrome_driver() -> Any:
+    assert ChromeOptions is not None  # nosec - guarded by caller
+    options = ChromeOptions()
+    # Allow Selenium Manager to discover the binary but prefer headless execution.
+    if hasattr(options, "add_argument"):
+        options.add_argument("--headless=new")
+        options.add_argument("--disable-gpu")
+        options.add_argument("--disable-extensions")
+        options.add_argument("--window-size=1280,800")
+    return webdriver.Chrome(options=options)
+
+
+def _create_edge_driver() -> Any:
+    assert EdgeOptions is not None  # nosec - guarded by caller
+    options = EdgeOptions()
+    if hasattr(options, "use_chromium"):
+        options.use_chromium = True
+    if hasattr(options, "add_argument"):
+        options.add_argument("--headless=new")
+        options.add_argument("--disable-gpu")
+        options.add_argument("--disable-extensions")
+        options.add_argument("--window-size=1280,800")
+    return webdriver.Edge(options=options)
+
+
+def _create_firefox_driver() -> Any:
+    assert FirefoxOptions is not None  # nosec - guarded by caller
+    options = FirefoxOptions()
+    if hasattr(options, "add_argument"):
+        options.add_argument("-headless")
+    else:
+        options.headless = True
+    return webdriver.Firefox(options=options)
+
+
+def _available_browser_factories() -> List[Tuple[str, Any]]:
+    factories: List[Tuple[str, Any]] = []
+    if webdriver is None or By is None:
+        return factories
+    if ChromeOptions is not None:
+        factories.append(("Chrome", _create_chrome_driver))
+    if EdgeOptions is not None:
+        factories.append(("Edge", _create_edge_driver))
+    if FirefoxOptions is not None:
+        factories.append(("Firefox", _create_firefox_driver))
+    return factories
+
+
+def _collect_headers_from_driver(driver: Any) -> Optional[Dict[str, str]]:
+    if By is None:
+        return None
+    user_agent: Optional[str]
+    languages: Optional[Any]
+    data: Dict[str, Any]
+    try:
+        driver.get(HTTPBIN_HEADERS_URL)
+        time.sleep(1)
+        body_element = driver.find_element(By.TAG_NAME, "body")
+        text = body_element.text if body_element is not None else ""
+        data = json.loads(text) if text else {}
+    except Exception:
+        data = {}
+    try:
+        user_agent = driver.execute_script("return navigator.userAgent")
+    except Exception:
+        user_agent = None
+    try:
+        languages = driver.execute_script("return navigator.languages || []")
+    except Exception:
+        languages = None
+    headers: Dict[str, str] = {}
+    payload_headers = data.get("headers") if isinstance(data, dict) else None
+    if isinstance(payload_headers, dict):
+        for key, value in payload_headers.items():
+            if key in BROWSER_HEADER_KEYS and isinstance(value, str):
+                headers[key] = value
+    if user_agent and "User-Agent" not in headers:
+        headers["User-Agent"] = str(user_agent)
+    if languages and isinstance(languages, list) and "Accept-Language" not in headers:
+        language_values = [str(lang) for lang in languages if isinstance(lang, str)]
+        if language_values:
+            headers["Accept-Language"] = ",".join(language_values)
+    return headers or None
+
+
+def _probe_browser_headers() -> Tuple[Optional[Dict[str, str]], Optional[str], List[str]]:
+    factories = _available_browser_factories()
+    if not factories:
+        return None, None, ["Selenium webdriver is unavailable"]
+
+    attempts: List[str] = []
+    for name, factory in factories:
+        driver = None
+        try:
+            driver = factory()
+        except WebDriverException as exc:  # pragma: no cover - requires browsers
+            attempts.append(f"{name} launch failed: {exc}")
+            continue
+        except Exception as exc:  # pragma: no cover - unexpected failures
+            attempts.append(f"{name} launch error: {exc}")
+            continue
+        try:
+            headers = _collect_headers_from_driver(driver)
+        finally:
+            try:
+                driver.quit()
+            except Exception:
+                pass
+        if headers:
+            return headers, name, attempts
+        attempts.append(f"{name} did not yield headers")
+    return None, None, attempts
+
+
 def _server_post(session: requests.Session, url: str, path: str, json_payload: dict, timeout: int = 30) -> dict:
     response = session.post(f"{url}{path}", json=json_payload, timeout=timeout)
     response.raise_for_status()
@@ -178,7 +341,7 @@ def _execute_stratz_query(session: requests.Session, token: str, query: str, var
     headers = {
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
-        "Accept": "application/json, text/plain, */*",
+        "Accept": session.headers.get("Accept", "application/json, text/plain, */*"),
         "apollographql-client-name": "web",
         "apollographql-client-version": "1.0",
     }
@@ -359,23 +522,36 @@ def worker_entry(config: WorkerConfig, stop_event: Event, queue: Queue) -> None:
     token_value = config.token_value.strip()
     session = requests.Session()
     stratz_session = requests.Session()
-    stratz_session.headers.update(
-        {
-            "User-Agent": (
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-                "AppleWebKit/537.36 (KHTML, like Gecko) "
-                "Chrome/126.0.0.0 Safari/537.36"
-            ),
-            "Accept": "application/json, text/plain, */*",
-            "Accept-Language": "en-US,en;q=0.9",
-            "Accept-Encoding": "gzip, deflate, br, zstd",
-            "Origin": "https://stratz.com",
-            "Referer": "https://stratz.com/",
-            "Sec-Ch-Ua": '"Not/A)Brand";v="8", "Chromium";v="126", "Google Chrome";v="126"',
-            "Sec-Ch-Ua-Mobile": "?0",
-            "Sec-Ch-Ua-Platform": '"Windows"',
-        }
-    )
+    browser_headers, browser_name, header_attempts = _probe_browser_headers()
+    if browser_headers:
+        stratz_session.headers.clear()
+        stratz_session.headers.update(browser_headers)
+        for key, value in DEFAULT_STRATZ_HEADERS.items():
+            stratz_session.headers.setdefault(key, value)
+        _send_log(
+            queue,
+            config.token_id,
+            f"Captured {browser_name} headers via Selenium for Stratz requests.",
+        )
+    else:
+        stratz_session.headers.update(DEFAULT_STRATZ_HEADERS)
+        if header_attempts:
+            truncated = "; ".join(header_attempts[:2])
+            if len(header_attempts) > 2:
+                truncated += "; ..."
+            _send_log(
+                queue,
+                config.token_id,
+                f"Falling back to bundled headers. Selenium errors: {truncated}",
+            )
+        else:
+            _send_log(
+                queue,
+                config.token_id,
+                "Falling back to bundled headers. Selenium not available.",
+            )
+    stratz_session.headers.setdefault("Origin", "https://stratz.com")
+    stratz_session.headers.setdefault("Referer", "https://stratz.com/")
     requests_remaining = config.max_requests
     completed_tasks = 0
     start_ms = _monotonic_ms()

--- a/stratz_scraper/client/worker.py
+++ b/stratz_scraper/client/worker.py
@@ -21,8 +21,6 @@ DEFAULT_STRATZ_HEADERS = {
     "Accept": "*/*",
     "Accept-Language": "en-GB,en;q=0.5",
     "Accept-Encoding": "gzip, deflate, br, zstd",
-    "Referer": "http://scraper.nitjsefni.eu/",
-    "Origin": "http://scraper.nitjsefni.eu",
     "Connection": "keep-alive",
     "Sec-Fetch-Dest": "empty",
     "Sec-Fetch-Mode": "cors",
@@ -192,10 +190,11 @@ def _execute_stratz_query(session: requests.Session, token: str, query: str, var
         **DEFAULT_STRATZ_HEADERS,
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
-        "Accept": session.headers.get("Accept", "*/*"),
         "apollographql-client-name": "web",
         "apollographql-client-version": "1.0"
     }
+    print("POST headers:", headers)
+    print("POST body:", {"query": query, "variables": variables})
     response = session.post(
         "https://api.stratz.com/graphql",
         headers=headers,


### PR DESCRIPTION
## Summary
- replace the browser UI with a standalone PyQt client that manages Stratz tokens, progress polling, and seed/leaderboard views
- add a multiprocessing worker implementation so each token runs in an isolated process while reporting status back to the UI
- document the desktop client, add dedicated requirements, and configure a Windows GitHub Actions job to build a PyInstaller artifact

## Testing
- python -m compileall stratz_scraper/client

------
https://chatgpt.com/codex/tasks/task_e_68d7d2a6626c83249a48e73e55d1e66d