### PR TITLE
Run assignment cleanup in background worker

### DIFF
--- a/stratz_scraper/web/app.py
+++ b/stratz_scraper/web/app.py
@@ -8,7 +8,7 @@ from flask import Flask, Response, abort, jsonify, render_template, request
 
 from ..database import db_connection, retryable_execute, release_incomplete_assignments
 from ..heroes import HEROES
-from .assignment import assign_next_task
+from .assignment import assign_next_task, ensure_assignment_cleanup_scheduler
 from .config import STATIC_DIR, TEMPLATE_DIR
 from .leaderboard import fetch_best_payload, fetch_hero_leaderboard
 from .progress import fetch_progress
@@ -116,6 +116,7 @@ def create_app() -> Flask:
     )
 
     release_incomplete_assignments()
+    ensure_assignment_cleanup_scheduler()
 
     @app.get("/")
     def index() -> str:


### PR DESCRIPTION
## Summary
- start a background worker that periodically invokes the assignment cleanup routine
- ensure the Flask app boots the cleanup scheduler so task assignment no longer blocks on cleanup

## Testing
- python -m compileall stratz_scraper

------
https://chatgpt.com/codex/tasks/task_e_68d7ee4721ec8324b889b0016daf239c