### PR TITLE
Adjust hero refresh seen index ordering

### DIFF
--- a/stratz_scraper/database.py
+++ b/stratz_scraper/database.py
@@ -250,14 +250,16 @@ def ensure_indexes(*, lock_acquired: bool = False) -> None:
                         COALESCE(hero_refreshed_at, '1970-01-01'),
                         steamAccountId
                     );
-                CREATE INDEX IF NOT EXISTS idx_players_hero_refresh_seen
+                DROP INDEX IF EXISTS idx_players_hero_refresh_seen;
+                CREATE INDEX idx_players_hero_refresh_seen
                     ON players (
                         hero_done,
                         assigned_to,
-                        seen_count DESC,
                         COALESCE(hero_refreshed_at, '1970-01-01'),
+                        seen_count DESC,
                         steamAccountId
-                    );
+                    )
+                    WHERE hero_done=1 AND assigned_to IS NULL;
                 CREATE INDEX IF NOT EXISTS idx_players_discover_queue
                     ON players (
                         hero_done,


### PR DESCRIPTION
## Summary
- drop and recreate `idx_players_hero_refresh_seen` with the refreshed-at column preceding the seen counter
- limit the index to completed, unassigned heroes so it stays lean

## Testing
- `python - <<'PY'
import importlib.util
import sys
import types
from pathlib import Path

package_name = "stratz_scraper"
package = types.ModuleType(package_name)
package.__path__ = [str(Path(package_name))]
sys.modules[package_name] = package

spec = importlib.util.spec_from_file_location(
    f"{package_name}.database",
    Path(package_name) / "database.py",
    submodule_search_locations=[str(Path(package_name))],
)
module = importlib.util.module_from_spec(spec)
sys.modules[spec.name] = module
spec.loader.exec_module(module)

module.ensure_schema_exists()
print("schema ensured")
PY`
- `sqlite3 dota.db "EXPLAIN QUERY PLAN SELECT steamAccountId FROM players WHERE hero_done=1 AND assigned_to IS NULL ORDER BY COALESCE(hero_refreshed_at, '1970-01-01') ASC, seen_count DESC, steamAccountId ASC LIMIT 1;"`


------
https://chatgpt.com/codex/tasks/task_e_68d7f0a6a19083249daaa6abbf1a8b68