### PR TITLE
Improve hero task assignment indexing

### DIFF
--- a/stratz_scraper/database.py
+++ b/stratz_scraper/database.py
@@ -291,6 +291,9 @@ def ensure_indexes(*, lock_acquired: bool = False) -> None:
                 CREATE INDEX IF NOT EXISTS idx_players_hero_cursor
                     ON players (steamAccountId)
                     WHERE hero_done=0 AND assigned_to IS NULL;
+                CREATE INDEX IF NOT EXISTS idx_players_hero_pending
+                    ON players (steamAccountId)
+                    WHERE hero_done=0;
                 CREATE INDEX IF NOT EXISTS idx_players_hero_refresh
                     ON players (
                         hero_done,


### PR DESCRIPTION
## Summary
- add a partial index for pending hero records so the hero assignment path no longer scans the whole players table

## Testing
- python -m compileall stratz_scraper

------
https://chatgpt.com/codex/tasks/task_e_68d82247531883249419b9f6b73d8111