### PR TITLE
Add win rates and account links to leaderboard tables

### DIFF
--- a/stratz_scraper/web/templates/leaderboard.html
+++ b/stratz_scraper/web/templates/leaderboard.html
@@ -35,7 +35,7 @@
               {% set win_rate = (player.matches and (player.wins / player.matches * 100)) or 0 %}
               <tr>
                 <td>{{ loop.index }}</td>
-                <td>{{ player.steamAccountId }}</td>
+                <td><a href="https://stratz.com/players/{{ player.steamAccountId }}" target="_blank" rel="noopener">{{ player.steamAccountId }}</a></td>
                 <td>{{ player.matches }}</td>
                 <td>{{ player.wins }}</td>
                 <td>{{ '%.1f' % win_rate }}%</td>


### PR DESCRIPTION
## Summary
- add a win rate column to the dashboard leaderboard and link Steam account IDs to Stratz profiles
- link Steam account IDs to Stratz profiles on individual hero leaderboards

## Testing
- python -m compileall stratz_scraper

------
https://chatgpt.com/codex/tasks/task_e_68d95dbe5b8883249bb8c739e2d3ad2f