### PR TITLE
Remove hero ID column from best heroes table

### DIFF
--- a/stratz_scraper/web/static/js/app.js
+++ b/stratz_scraper/web/static/js/app.js
@@ -1150,7 +1150,6 @@ function renderBestTable(rows) {
       <thead>
         <tr>
           <th>Hero</th>
-          <th>Hero ID</th>
           <th>Steam Account ID</th>
           <th>Matches</th>
           <th>Wins</th>
@@ -1174,7 +1173,6 @@ function renderBestTable(rows) {
       return `
         <tr>
           <td>${heroCell}</td>
-          <td>${formatCell(row?.hero_id)}</td>
           <td>${playerCell}</td>
           <td>${formatCell(row?.matches)}</td>
           <td>${formatCell(row?.wins)}</td>


### PR DESCRIPTION
## Summary
- remove the hero ID column from the top heroes table rendered on the index page so only player-facing data remains

## Testing
- python app.py

------
https://chatgpt.com/codex/tasks/task_e_68dccd4cd4ec8324b602caf6cdbb06d6