### PR TITLE
Remove task duration tracking

### DIFF
--- a/stratz_scraper/database.py
+++ b/stratz_scraper/database.py
@@ -183,7 +183,6 @@ def ensure_schema(*, lock_acquired: bool = False) -> None:
                 DROP TABLE IF EXISTS players;
                 DROP TABLE IF EXISTS meta;
                 DROP TABLE IF EXISTS best;
-                DROP TABLE IF EXISTS task_durations;
 
                 CREATE TABLE players (
                     steamAccountId INTEGER PRIMARY KEY,
@@ -217,14 +216,6 @@ def ensure_schema(*, lock_acquired: bool = False) -> None:
                     value TEXT NOT NULL
                 );
 
-                CREATE TABLE task_durations (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    steamAccountId INTEGER,
-                    task_type TEXT NOT NULL,
-                    assigned_at DATETIME,
-                    submitted_at DATETIME,
-                    duration_seconds REAL
-                );
                 """
             )
             conn.execute(
@@ -259,20 +250,6 @@ def ensure_indexes(*, lock_acquired: bool = False) -> None:
             )
             conn.executescript(
                 """
-                CREATE TABLE IF NOT EXISTS task_durations (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    steamAccountId INTEGER,
-                    task_type TEXT NOT NULL,
-                    assigned_at DATETIME,
-                    submitted_at DATETIME,
-                    duration_seconds REAL
-                );
-                CREATE INDEX IF NOT EXISTS idx_task_durations_account
-                    ON task_durations (steamAccountId);
-                CREATE INDEX IF NOT EXISTS idx_task_durations_type
-                    ON task_durations (task_type);
-                CREATE INDEX IF NOT EXISTS idx_task_durations_submitted
-                    ON task_durations (submitted_at);
                 CREATE INDEX IF NOT EXISTS idx_players_hero_queue
                     ON players (
                         hero_done,


### PR DESCRIPTION
## Summary
- remove the task_durations table from the SQLite schema setup
- delete task duration recording logic from the background submission helpers

## Testing
- python -m compileall stratz_scraper

------
https://chatgpt.com/codex/tasks/task_e_68df7ac08404832482a1525fa3e9d2b6