### PR TITLE
Simplify submission timestamp handling

### DIFF
--- a/stratz_scraper/database.py
+++ b/stratz_scraper/database.py
@@ -309,11 +309,13 @@ def ensure_indexes(*, lock_acquired: bool = False) -> None:
                     WHERE hero_done=1
                       AND discover_done=0
                       AND (assigned_to IS NULL OR assigned_to='discover');
+                DROP INDEX IF EXISTS idx_players_assignment_state;
                 CREATE INDEX IF NOT EXISTS idx_players_assignment_state
                     ON players (
                         assigned_to,
                         assigned_at
-                    );
+                    )
+                    WHERE assigned_to IS NOT NULL;
                 CREATE UNIQUE INDEX IF NOT EXISTS idx_meta_key
                     ON meta (key);
                 CREATE INDEX IF NOT EXISTS idx_hero_stats_leaderboard

--- a/stratz_scraper/web/submissions.py
+++ b/stratz_scraper/web/submissions.py
@@ -65,7 +65,6 @@ def process_hero_submission(
     steam_account_id: int,
     hero_stats_rows: Sequence[tuple[int, int, int, int]],
     best_rows: Sequence[tuple[int, str, int, int, int]],
-    assigned_at_value: str | None,
 ) -> None:
     try:
         with db_connection(write=True) as conn:
@@ -128,7 +127,6 @@ def process_discover_submission(
     steam_account_id: int,
     discovered_counts: Iterable[tuple[int, int]],
     next_depth_value: int,
-    assigned_at_value: str | None,
 ) -> None:
     try:
         with db_connection(write=True) as conn:
@@ -186,14 +184,12 @@ def submit_hero_submission(
     steam_account_id: int,
     hero_stats_rows: Sequence[tuple[int, int, int, int]],
     best_rows: Sequence[tuple[int, str, int, int, int]],
-    assigned_at_value: str | None,
 ) -> None:
     BACKGROUND_EXECUTOR.submit(
         process_hero_submission,
         steam_account_id,
         hero_stats_rows,
         best_rows,
-        assigned_at_value,
     )
 
 
@@ -201,12 +197,10 @@ def submit_discover_submission(
     steam_account_id: int,
     discovered_counts: Iterable[tuple[int, int]],
     next_depth_value: int,
-    assigned_at_value: str | None,
 ) -> None:
     BACKGROUND_EXECUTOR.submit(
         process_discover_submission,
         steam_account_id,
         tuple(discovered_counts),
         next_depth_value,
-        assigned_at_value,
     )


### PR DESCRIPTION
## Summary
- remove the assigned_at_value parameter from submission helpers and background scheduling
- simplify submit handler bookkeeping and rely on update rowcounts for missing hero assignments while only fetching depth for discovery
- tighten the assignment state index to only track rows currently assigned

## Testing
- python -m compileall stratz_scraper

------
https://chatgpt.com/codex/tasks/task_e_68df7eb746e88324b0760ce86fdb2ce5