### PR TITLE
Guard empty discovery submissions

### DIFF
--- a/stratz_scraper/web/app.py
+++ b/stratz_scraper/web/app.py
@@ -223,11 +223,12 @@ def create_app() -> Flask:
                     jsonify({"status": "error", "message": "Player not found"}),
                     404,
                 )
-            submit_discover_submission(
-                steam_account_id,
-                discovered_counts,
-                next_depth_value,
-            )
+            if discovered_counts:
+                submit_discover_submission(
+                    steam_account_id,
+                    discovered_counts,
+                    next_depth_value,
+                )
             next_task = assign_next_task() if request_new_task else None
             response_payload = {"status": "ok"}
             if request_new_task:

--- a/stratz_scraper/web/submissions.py
+++ b/stratz_scraper/web/submissions.py
@@ -203,12 +203,14 @@ def submit_hero_submission(
 
 def submit_discover_submission(
     steam_account_id: int,
-    discovered_counts: Iterable[tuple[int, int]],
+    discovered_counts: Sequence[tuple[int, int]],
     next_depth_value: int,
 ) -> None:
+    if not discovered_counts:
+        return
     BACKGROUND_EXECUTOR.submit(
         process_discover_submission,
         steam_account_id,
-        tuple(discovered_counts),
+        discovered_counts,
         next_depth_value,
     )


### PR DESCRIPTION
## Summary
- guard the discover submission path to only enqueue background work when new players were reported
- make `submit_discover_submission` ignore empty payloads and pass lists through unchanged

## Testing
- python -m compileall stratz_scraper

------
https://chatgpt.com/codex/tasks/task_e_68df82037e088324900f68cc0603dc41