### PR TITLE
Add overall leaderboards endpoint

### DIFF
--- a/stratz_scraper/web/app.py
+++ b/stratz_scraper/web/app.py
@@ -13,7 +13,11 @@ from ..database import (
 )
 from .assignment import assign_next_task, ensure_assignment_cleanup_scheduler
 from .config import STATIC_DIR, TEMPLATE_DIR
-from .leaderboard import fetch_best_payload, fetch_hero_leaderboard
+from .leaderboard import (
+    fetch_best_payload,
+    fetch_hero_leaderboard,
+    fetch_overall_leaderboard,
+)
 from .progress import fetch_progress
 from .request_utils import is_local_request
 from .seed import seed_players
@@ -182,6 +186,20 @@ def create_app() -> Flask:
         seed_players(start, end)
         return jsonify({"seeded": [start, end]})
 
+    @app.get("/leaderboards")
+    @app.get("/leaderboards/")
+    def leaderboards():
+        players = fetch_overall_leaderboard()
+        return render_template(
+            "leaderboard.html",
+            hero_name="Overall",
+            hero_slug=None,
+            players=players,
+            heading="Overall Leaderboard",
+            page_title="Overall Leaderboard",
+            description="Top 100 players by matches played across all heroes.",
+        )
+
     @app.get("/leaderboards/<hero_slug>")
     def hero_leaderboard(hero_slug: str):
         hero_payload = fetch_hero_leaderboard(hero_slug)
@@ -193,6 +211,9 @@ def create_app() -> Flask:
             hero_name=hero_name,
             hero_slug=slug,
             players=players,
+            heading=f"{hero_name} Leaderboard",
+            page_title=f"{hero_name} Leaderboard",
+            description=f"Top 100 players by matches played on {hero_name}.",
         )
 
     @app.get("/best")

--- a/stratz_scraper/web/templates/leaderboard.html
+++ b/stratz_scraper/web/templates/leaderboard.html
@@ -2,16 +2,19 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>{{ hero_name }} Leaderboard - Dota Distributed Scraper</title>
+    {% set resolved_title = page_title or (hero_name ~ ' Leaderboard') %}
+    <title>{{ resolved_title }} - Dota Distributed Scraper</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
   </head>
   <body>
     <main class="container">
       <header class="page-header">
+        {% set resolved_heading = heading or (hero_name ~ ' Leaderboard') %}
+        {% set resolved_description = description or ('Top 100 players by matches played on ' ~ hero_name ~ '.') %}
         <div>
-          <h1>{{ hero_name }} Leaderboard</h1>
-          <p class="lead">Top 100 players by matches played on {{ hero_name }}.</p>
+          <h1>{{ resolved_heading }}</h1>
+          <p class="lead">{{ resolved_description }}</p>
         </div>
         <a href="{{ url_for('index') }}">Back to dashboard</a>
       </header>


### PR DESCRIPTION
## Summary
- add an aggregated `/leaderboards` route that surfaces the top 100 players across all heroes
- extend the leaderboard template to allow custom titles and descriptions so it can be reused for the global view
- expose a `fetch_overall_leaderboard` helper that sums hero stats per player

## Testing
- python -m compileall stratz_scraper

------
https://chatgpt.com/codex/tasks/task_e_68dfa7551db48324bf72c8ec338cad20