### PR TITLE
Add index to support overall leaderboard

### DIFF
--- a/stratz_scraper/database.py
+++ b/stratz_scraper/database.py
@@ -325,6 +325,13 @@ def ensure_indexes(*, lock_acquired: bool = False) -> None:
                         wins DESC,
                         steamAccountId
                     );
+                CREATE INDEX IF NOT EXISTS idx_hero_stats_overall_leaderboard
+                    ON hero_stats (
+                        steamAccountId,
+                        matches DESC,
+                        wins DESC,
+                        heroId
+                    );
                 """
             )
     _INDEXES_ENSURED = True


### PR DESCRIPTION
## Summary
- add a composite index on hero_stats to speed up overall leaderboard aggregation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfa92c55bc83249a6c2e6a4f4b5f68