### PR TITLE
Show hero names on overall leaderboard

### DIFF
--- a/stratz_scraper/web/leaderboard.py
+++ b/stratz_scraper/web/leaderboard.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Dict, List, Optional, Tuple
 
 from ..database import db_connection
-from ..heroes import HERO_SLUGS, hero_slug
+from ..heroes import HEROES, HERO_SLUGS, hero_slug
 
 __all__ = ["fetch_best_payload", "fetch_hero_leaderboard", "fetch_overall_leaderboard"]
 
@@ -38,7 +38,7 @@ def fetch_hero_leaderboard(slug: str) -> Optional[Tuple[str, str, List[dict]]]:
     return hero_name, normalized, players
 
 
-def fetch_overall_leaderboard() -> List[Dict[str, int]]:
+def fetch_overall_leaderboard() -> List[Dict[str, object]]:
     with db_connection() as conn:
         rows = conn.execute(
             """
@@ -48,13 +48,18 @@ def fetch_overall_leaderboard() -> List[Dict[str, int]]:
             LIMIT 100
             """
         ).fetchall()
-    players: List[Dict[str, int]] = []
+    players: List[Dict[str, object]] = []
     for row in rows:
+        hero_id = row["heroId"]
+        hero_name = HEROES.get(hero_id)
+        hero_slug_value = hero_slug(hero_name) if isinstance(hero_name, str) else None
         players.append(
             {
                 "steamAccountId": row["steamAccountId"],
                 "matches": row["matches"] or 0,
                 "wins": row["wins"] or 0,
+                "heroName": hero_name,
+                "heroSlug": hero_slug_value,
             }
         )
     return players

--- a/stratz_scraper/web/templates/leaderboard.html
+++ b/stratz_scraper/web/templates/leaderboard.html
@@ -28,6 +28,7 @@
               <tr>
                 <th scope="col">Rank</th>
                 <th scope="col">Steam Account ID</th>
+                <th scope="col">Hero</th>
                 <th scope="col">Matches</th>
                 <th scope="col">Wins</th>
                 <th scope="col">Win Rate</th>
@@ -39,6 +40,17 @@
               <tr>
                 <td>{{ loop.index }}</td>
                 <td><a href="https://stratz.com/players/{{ player.steamAccountId }}" target="_blank" rel="noopener">{{ player.steamAccountId }}</a></td>
+                <td>
+                  {% if player.heroName %}
+                    {% if player.heroSlug %}
+                    <a href="{{ url_for('hero_leaderboard', hero_slug=player.heroSlug) }}">{{ player.heroName }}</a>
+                    {% else %}
+                    {{ player.heroName }}
+                    {% endif %}
+                  {% else %}
+                    <span class="muted">Unknown</span>
+                  {% endif %}
+                </td>
                 <td>{{ player.matches }}</td>
                 <td>{{ player.wins }}</td>
                 <td>{{ '%.1f' % win_rate }}%</td>


### PR DESCRIPTION
## Summary
- map overall leaderboard entries to localized hero names and slugs
- expose hero names in the rendered leaderboard table with links to hero pages

## Testing
- python -m compileall stratz_scraper

------
https://chatgpt.com/codex/tasks/task_e_68dfb69bac94832494494d75d2e23b60