### PR TITLE
Add token collapse controls and preserve manual state

### DIFF
--- a/stratz_scraper/web/templates/index.html
+++ b/stratz_scraper/web/templates/index.html
@@ -33,6 +33,7 @@
           </div>
           <div class="token-controls">
             <button id="addToken" type="button" class="secondary">Add token</button>
+            <button id="toggleTokens" type="button" class="secondary">Collapse all</button>
             <div class="token-control-group">
               <button id="exportTokens" type="button" class="secondary">Export all</button>
               <button id="importTokens" type="button" class="secondary">Import all</button>


### PR DESCRIPTION
## Summary
- add a toolbar control that collapses or expands every token at once
- keep manually collapsed tokens closed when their worker starts running
- keep the collapse toggle label in sync with token state changes

## Testing
- python -m compileall stratz_scraper

------
https://chatgpt.com/codex/tasks/task_e_68dfc425c8c083249eaa2e516f2a17a2